### PR TITLE
test(ci) Stage 2.5: Enable ubuntu, win 2022, exclude or fix failing tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -229,6 +229,7 @@ Target "RunTests" (fun _ ->
                                        -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Codecs.Http2.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Handlers.Tests.csproj"
+                                       -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
      
         let runSingleProject project =

--- a/build.fsx
+++ b/build.fsx
@@ -223,6 +223,7 @@ Target "RunTests" (fun _ ->
                                 | true -> !! "./test/*.Tests/*.Tests.csproj"
                                           -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
                                           -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
+                                          -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
                                 | _ -> !! "./test/*.Tests/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
                                        -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"

--- a/build.fsx
+++ b/build.fsx
@@ -226,6 +226,8 @@ Target "RunTests" (fun _ ->
                                 | _ -> !! "./test/*.Tests/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
                                        -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
+                                       -- "./test/*.Tests/DotNetty.Codecs.Http2.Tests.csproj"
+                                       -- "./test/*.Tests/DotNetty.Handlers.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
      
         let runSingleProject project =

--- a/build.fsx
+++ b/build.fsx
@@ -227,7 +227,6 @@ Target "RunTests" (fun _ ->
                                 | _ -> !! "./test/*.Tests/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
                                        -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
-                                       -- "./test/*.Tests/DotNetty.Codecs.Http2.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Handlers.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
             rawProjects |> Seq.choose filterProjects

--- a/build.fsx
+++ b/build.fsx
@@ -221,14 +221,13 @@ Target "RunTests" (fun _ ->
         let projects = 
             let rawProjects = match (isWindows) with 
                                 | true -> !! "./test/*.Tests/*.Tests.csproj"
-                                          -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
-                                          -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
-                                          -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
+                                    -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
+                                    -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
+                                    -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
                                 | _ -> !! "./test/*.Tests/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
-                                       -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
-                                       -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
-                                       -- "./test/*.Tests/DotNetty.Handlers.Tests.csproj"
-                                       -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
+                                    -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
+                                    -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
+                                    -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
      
         let runSingleProject project =

--- a/build.fsx
+++ b/build.fsx
@@ -221,13 +221,13 @@ Target "RunTests" (fun _ ->
         let projects = 
             let rawProjects = match (isWindows) with 
                                 | true -> !! "./test/*.Tests/*.Tests.csproj"
-                                    -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
-                                    -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
-                                    -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
+                                          -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
+                                          -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
+                                          -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
                                 | _ -> !! "./test/*.Tests/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
-                                    -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
-                                    -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
-                                    -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
+                                       -- "./test/*.Tests/DotNetty.Transport.Tests.csproj"
+                                       -- "./test/*.Tests/DotNetty.Suite.Tests.csproj"
+                                       -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
      
         let runSingleProject project =

--- a/build/pr-netfx-validation.yaml
+++ b/build/pr-netfx-validation.yaml
@@ -16,9 +16,7 @@ pr:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
-  NUGET_XMLDOC_MODE: none
-  NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED: 'true'
-  packageFeed: 'https://pkgs.dev.azure.com/msazure/_packaging/ApiManagement/nuget/v3/index.json'
+- template: variables/nuget.yml
 
 stages:
 - stage: windows

--- a/build/pr-validation.yaml
+++ b/build/pr-validation.yaml
@@ -16,9 +16,7 @@ pr:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
-  NUGET_XMLDOC_MODE: none
-  NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED: 'true'
-  packageFeed: 'https://pkgs.dev.azure.com/msazure/_packaging/ApiManagement/nuget/v3/index.json'
+- template: variables/nuget.yml
 
 stages:
 - stage: windows

--- a/build/pr-validation.yaml
+++ b/build/pr-validation.yaml
@@ -57,16 +57,16 @@ stages:
         displayName: 'If above is partially succeeded, then fail'
         condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
 
-  # - template: templates/azure-pipeline.template.yaml
-  #   parameters:
-  #     name: 'net_core_tests_windows_2022'
-  #     displayName: 'Unit Tests (Windows 2022)'
-  #     vmImage: 'windows-2022'
-  #     scriptFileName: build.cmd
-  #     scriptArgs: RunTests incremental
-  #     outputDirectory: 'TestResults'
-  #     artifactName: 'net_core_tests_windows-$(Build.BuildId)'
-  #     packageFeed: $(packageFeed)
+  - template: templates/azure-pipeline.template.yaml
+    parameters:
+      name: 'net_core_tests_windows_2022'
+      displayName: 'Unit Tests (Windows 2022)'
+      vmImage: 'windows-2022'
+      scriptFileName: build.cmd
+      scriptArgs: RunTests incremental
+      outputDirectory: 'TestResults'
+      artifactName: 'net_core_tests_windows-$(Build.BuildId)'
+      packageFeed: $(packageFeed)
 
   - template: templates/azure-pipeline.template.yaml
     parameters:
@@ -79,28 +79,28 @@ stages:
       artifactName: 'net_core_tests_windows-$(Build.BuildId)'
       packageFeed: $(packageFeed)
 
-# - stage: linux
-#   displayName: Linux (Ubuntu)
-#   dependsOn: []
-#   jobs:
-#   - template: templates/azure-pipeline.template.yaml
-#     parameters:
-#       name: 'net_core_tests_ubuntu_20'
-#       displayName: 'Unit Tests (Ubuntu-20)'
-#       vmImage: 'ubuntu-20.04'
-#       scriptFileName: './build.sh'
-#       scriptArgs: RunTests incremental
-#       outputDirectory: 'TestResults'
-#       artifactName: 'net_core_tests_ubuntu_16-$(Build.BuildId)'
-#       packageFeed: $(packageFeed)
+- stage: linux
+  displayName: Linux (Ubuntu)
+  dependsOn: []
+  jobs:
+  - template: templates/azure-pipeline.template.yaml
+    parameters:
+      name: 'net_core_tests_ubuntu_20'
+      displayName: 'Unit Tests (Ubuntu-20)'
+      vmImage: 'ubuntu-20.04'
+      scriptFileName: './build.sh'
+      scriptArgs: RunTests incremental
+      outputDirectory: 'TestResults'
+      artifactName: 'net_core_tests_ubuntu_16-$(Build.BuildId)'
+      packageFeed: $(packageFeed)
 
-#   - template: templates/azure-pipeline.template.yaml
-#     parameters:
-#       name: 'net_core_tests_ubuntu_22'
-#       displayName: 'Unit Tests (Ubuntu-22)'
-#       vmImage: 'ubuntu-22.04'
-#       scriptFileName: './build.sh'
-#       scriptArgs: RunTests incremental
-#       outputDirectory: 'TestResults'
-#       artifactName: 'net_core_tests_ubuntu_22-$(Build.BuildId)'
-#       packageFeed: $(packageFeed)
+  - template: templates/azure-pipeline.template.yaml
+    parameters:
+      name: 'net_core_tests_ubuntu_22'
+      displayName: 'Unit Tests (Ubuntu-22)'
+      vmImage: 'ubuntu-22.04'
+      scriptFileName: './build.sh'
+      scriptArgs: RunTests incremental
+      outputDirectory: 'TestResults'
+      artifactName: 'net_core_tests_ubuntu_22-$(Build.BuildId)'
+      packageFeed: $(packageFeed)

--- a/build/publish-packages.yaml
+++ b/build/publish-packages.yaml
@@ -8,9 +8,7 @@ trigger:
     - 'v*'
 
 variables:
-  NUGET_XMLDOC_MODE: none
-  NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED: 'true'
-  packageFeed: 'https://pkgs.dev.azure.com/msazure/_packaging/ApiManagement/nuget/v3/index.json'
+- template: variables/nuget.yml
 
 jobs:
   - job: publish

--- a/build/variables/nuget.yml
+++ b/build/variables/nuget.yml
@@ -1,0 +1,4 @@
+variables:
+  NUGET_XMLDOC_MODE: none
+  NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED: 'true'
+  packageFeed: 'https://pkgs.dev.azure.com/msazure/_packaging/ApiManagement/nuget/v3/index.json'

--- a/test/DotNetty.Handlers.Proxy.Tests/ProxyHandlerTest.cs
+++ b/test/DotNetty.Handlers.Proxy.Tests/ProxyHandlerTest.cs
@@ -86,7 +86,7 @@ namespace DotNetty.Handlers.Proxy.Tests
             ClearServerExceptions();
         }
         
-        [Theory(Timeout = 5000, Skip = "Unreliable test from upstream merge.")] // Infrequently fails in ubuntu and Win2022
+        [Theory(Timeout = 5000)] // Infrequently fails in ubuntu and Win2022
         [MemberData(nameof(CreateTestItems))]
         public void Test(TestItem item)
         {

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -66,12 +66,6 @@ namespace DotNetty.Handlers.Tests
             }
             else
             {
-                var legacyTls = !IsUbuntu2004();
-                if (legacyTls)
-                {
-                    protocols.Add(Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11));
-                    protocols.Add(Tuple.Create(SslProtocols.Tls11 | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11));
-                }
                 protocols.Add(Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12));
                 protocols.Add(Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls11, SslProtocols.Tls12 | SslProtocols.Tls11));
             }
@@ -179,12 +173,6 @@ namespace DotNetty.Handlers.Tests
             }
             else
             {
-                var legacyTls = !IsUbuntu2004();
-                if (legacyTls)
-                {
-                    protocols.Add(Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11));
-                    protocols.Add(Tuple.Create(SslProtocols.Tls11 | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11));
-                }
                 protocols.Add(Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12));
                 protocols.Add(Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls11, SslProtocols.Tls12 | SslProtocols.Tls11));
             }
@@ -407,41 +395,5 @@ namespace DotNetty.Handlers.Tests
         
         static bool IsWindowsBefore2022() 
             => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version < new Version(10, 0, 20348, 0);
-
-        static bool IsUbuntu2004()
-            => RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-               && Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystem == "ubuntu"
-               && Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemVersion == "20.04";
-
-        /*const string TlsKeyPrefix = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols";
-
-        static bool WindowsLegacyTlsEnabled()
-            => TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.0\\Client", "DisabledByDefault", out var val) && val == 0
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.0\\Client", "Enabled", out val) && val == 1
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.0\\Server", "DisabledByDefault", out val) && val == 0
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.0\\Server", "Enabled", out val) && val == 1
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.1\\Client", "DisabledByDefault", out val) && val == 0
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.1\\Client", "Enabled", out val) && val == 1
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.1\\Server", "DisabledByDefault", out val) && val == 0
-                && TryGetRegistryKey<int>($"{TlsKeyPrefix}\\TLS 1.1\\Server", "Enabled", out val) && val == 1;
-                
-        static bool TryGetRegistryKey<T>(string key, string name, out T result)
-        {
-            result = default;
-            try
-            {
-                var existingValue = Registry.GetValue(key, name, null);
-                if (existingValue is T res)
-                {
-                    result = res;
-                    return true;
-                }
-            }
-            catch
-            {
-            }
-
-            return false;
-        }*/
     }
 }


### PR DESCRIPTION
Enable ubuntu, win 2022, exclude or fix failing tests in order to get a meaningful green baseline that exercises all the environments targeted by APIM.

Targeting fixing following bugs:
- [Bug 26746422](https://msazure.visualstudio.com/One/_workitems/edit/26746422): Gateway V2 - SpanNetty - Re-enable win 2022 unit test pipeline, disable failing ProxyHandlerTests.Test and log bug
- [Bug 26682588](https://msazure.visualstudio.com/One/_workitems/edit/26682588): Gateway V2 - SpanNetty - Re-enable ubuntu Test pipelines, fix failing TlsHandlerTests, ProxyHandlerTests, and DotNetty.Codecs test timeout/crash