### PR TITLE
Skip pre TLS 1.2 TlsHandlerTests

### DIFF
--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -150,14 +150,6 @@ namespace DotNetty.Handlers.Tests
             var protocols = new List<Tuple<SslProtocols, SslProtocols>>();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var legacyTls = IsWindowsBefore2022();
-                if (legacyTls)
-                {
-                    protocols.Add(Tuple.Create(SslProtocols.Tls, SslProtocols.Tls));
-                    protocols.Add(Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11));
-                    protocols.Add(Tuple.Create(SslProtocols.Tls | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11));
-                }
-
                 protocols.Add(Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12));
 #if NETCOREAPP_3_0_GREATER
                 //protocols.Add(Tuple.Create(SslProtocols.Tls13, SslProtocols.Tls13));

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -51,13 +51,6 @@ namespace DotNetty.Handlers.Tests
             var protocols = new List<Tuple<SslProtocols, SslProtocols>>();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var legacyTls = IsWindowsBefore2022();
-                if (legacyTls)
-                {
-                    protocols.Add(Tuple.Create(SslProtocols.Tls, SslProtocols.Tls));
-                    protocols.Add(Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11));
-                    protocols.Add(Tuple.Create(SslProtocols.Tls | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11));
-                }
                 protocols.Add(Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12));
 #if NETCOREAPP_3_0_GREATER
                 //protocols.Add(Tuple.Create(SslProtocols.Tls13, SslProtocols.Tls13));
@@ -392,8 +385,5 @@ namespace DotNetty.Handlers.Tests
                 }
             }
         }
-        
-        static bool IsWindowsBefore2022() 
-            => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version < new Version(10, 0, 20348, 0);
     }
 }


### PR DESCRIPTION
It's not possible to reliably determine if particular test agent supports TLS 1.0 and 1.1 or not