### PR TITLE
ci: Don't trigger for main pushes & run tests in release

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -21,7 +21,7 @@ Remaining arguments are added here.
 Param(
     [string]$Target = "Default",
     [ValidateSet("Release", "Debug")]
-    [string]$Configuration = "Debug",
+    [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity = "Verbose",
     [switch]$WhatIf,

--- a/build/pr-netfx-validation.yaml
+++ b/build/pr-netfx-validation.yaml
@@ -36,7 +36,7 @@ stages:
         displayName: Windows Build
         inputs:
           filename: build.cmd
-          arguments: 'Build -Configuration Release'
+          arguments: 'Build'
         continueOnError: true
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
       - task: CopyFiles@2
@@ -57,7 +57,7 @@ stages:
       displayName: 'Unit Tests (Windows 2022)'
       vmImage: 'windows-2022'
       scriptFileName: build.cmd
-      scriptArgs: 'RunTestsNetFx471 -Configuration Release'
+      scriptArgs: RunTestsNetFx471
       outputDirectory: 'TestResults'
       artifactName: 'netfx_tests_windows-$(Build.BuildId)'
       packageFeed: $(packageFeed)

--- a/build/pr-netfx-validation.yaml
+++ b/build/pr-netfx-validation.yaml
@@ -1,10 +1,4 @@
-# Pull request validation for Windows against the `future` and `release/*` branches
-# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
-trigger:
-  branches:
-    include:
-      - main
-      - release/*
+trigger: none
 
 pr:
   autoCancel: true # indicates whether additional pushes to a PR should cancel in-progress runs for the same PR. Defaults to true
@@ -42,7 +36,7 @@ stages:
         displayName: Windows Build
         inputs:
           filename: build.cmd
-          arguments: 'Build' #Add ' incremental' to build incremental-ly
+          arguments: 'Build -Configuration Release'
         continueOnError: true
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
       - task: CopyFiles@2
@@ -63,7 +57,7 @@ stages:
       displayName: 'Unit Tests (Windows 2022)'
       vmImage: 'windows-2022'
       scriptFileName: build.cmd
-      scriptArgs: RunTestsNetFx471 #Add ' incremental' to Run tests incremental-ly
+      scriptArgs: 'RunTestsNetFx471 -Configuration Release'
       outputDirectory: 'TestResults'
       artifactName: 'netfx_tests_windows-$(Build.BuildId)'
       packageFeed: $(packageFeed)

--- a/build/pr-validation.yaml
+++ b/build/pr-validation.yaml
@@ -1,10 +1,4 @@
-# Pull request validation for Windows against the `future` and `release/*` branches
-# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
-trigger:
-  branches:
-    include:
-      - main
-      - release/*
+trigger: none
 
 pr:
   autoCancel: true # indicates whether additional pushes to a PR should cancel in-progress runs for the same PR. Defaults to true


### PR DESCRIPTION
- Don't run CI when merged to main (as PR already did the same)
- Run everything in Release mode, similar to release

It's good to note that tests always run in Debug anyway, as this is defined in Fake like this: https://github.com/maksimkim/SpanNetty/blob/a4ba4e6fe061b1bb6b40260248a373f3bf97ab45/build.fsx#L259-L261