### PR TITLE
fix: correctly rent arrays for ArrayPooledByteBufferTests

### DIFF
--- a/src/DotNetty.Buffers/ArrayPooledByteBuffer.cs
+++ b/src/DotNetty.Buffers/ArrayPooledByteBuffer.cs
@@ -82,16 +82,7 @@ namespace DotNetty.Buffers
 
         protected virtual void FreeArray(byte[] bytes)
         {
-#if DEBUG
-            // for unit testing
-            try
-            {
-                _arrayPool.Return(bytes);
-            }
-            catch { } // 防止回收非 BufferMannager 的 byte array 抛异常
-#else
             _arrayPool.Return(bytes);
-#endif
         }
 
         protected void SetArray(byte[] initialArray, int maxCapacity)

--- a/test/DotNetty.Buffers.Tests/AbstractArrayPooledByteBufferTests.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractArrayPooledByteBufferTests.cs
@@ -5,11 +5,13 @@
     using System.Linq;
     using System.Text;
     using System.Threading;
-    using DotNetty.Common.Utilities;
+    using Common.Utilities;
     using Xunit;
 
     public abstract partial class AbstractArrayPooledByteBufferTests : IDisposable
     {
+        protected const string TestCharSequence = "ABCDEFGHIJKLMNOPQRST"; // 20 chars
+        
         const int Capacity = 4096; // Must be even
         const int BlockSize = 128;
 

--- a/test/DotNetty.Buffers.Tests/ArrayPooledHeapByteBufferTests.cs
+++ b/test/DotNetty.Buffers.Tests/ArrayPooledHeapByteBufferTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Buffers;
+using System.Text;
 using DotNetty.Common.Utilities;
 
 namespace DotNetty.Buffers.Tests
@@ -9,11 +10,13 @@ namespace DotNetty.Buffers.Tests
 
         protected override void SetCharSequenceNoExpand(Encoding encoding)
         {
-            var array = new byte[1];
+            // by default ArrayPool buffers between 1 and 16 bytes are combined,
+            // so requesting length of 1 will still result in 16 bytes array
+            var array = ArrayPool<byte>.Shared.Rent(1);
             var buf = ArrayPooledHeapByteBuffer.NewInstance(ArrayPooled.Allocator, ArrayPooled.DefaultArrayPool, array, array.Length, array.Length);
             try
             {
-                buf.SetCharSequence(0, new StringCharSequence("AB"), encoding);
+                buf.SetCharSequence(0, new StringCharSequence(TestCharSequence), encoding);
             }
             finally
             {

--- a/test/DotNetty.Buffers.Tests/ArrayPooledTests.cs
+++ b/test/DotNetty.Buffers.Tests/ArrayPooledTests.cs
@@ -169,22 +169,22 @@ namespace DotNetty.Buffers.Tests
         {
             IList<IByteBuffer> expected = new List<IByteBuffer>();
             
-            expected.Add(WrappedBuffer(new byte[] { 1 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 2 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 }.RentThisData()));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4 }.RentThisData(), 1, 1));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4 }.RentThisData(), 2, 2));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }.RentThisData(), 1, 10));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }.RentThisData(), 2, 12));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5 }.RentThisData(), 2, 1));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5 }.RentThisData(), 3, 2));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }.RentThisData(), 2, 10));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }.RentThisData(), 3, 12));
+            expected.Add(WrappedBuffer(new byte[] { 1 }));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2 }));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }));
+            expected.Add(WrappedBuffer(new byte[] { 2 }));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3 }));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 }));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4 }, 1, 1));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4 }, 2, 2));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 1, 10));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 2, 12));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5 }, 2, 1));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5 }, 3, 2));
+            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 2, 10));
+            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, 3, 12));
 
             for (int i = 0; i < expected.Count; i++)
             {

--- a/test/DotNetty.Buffers.Tests/ArrayPooledTests.cs
+++ b/test/DotNetty.Buffers.Tests/ArrayPooledTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Buffers;
-using DotNetty.Common;
 
 namespace DotNetty.Buffers.Tests
 {
@@ -75,23 +74,22 @@ namespace DotNetty.Buffers.Tests
         [Fact]
         public void HashCode()
         {
-            var map = new Dictionary<byte[], (int length, int hashCode)>();
-            map.Add(EmptyBytes, (0, 1));
-            map.Add(new byte[] { 1 }.RentThisData(), (1, 32));
-            map.Add(new byte[] { 2 }.RentThisData(), (1, 33));
-            map.Add(new byte[] { 0, 1 }.RentThisData(), (2, 962));
-            map.Add(new byte[] { 1, 2 }.RentThisData(), (2, 994));
-            map.Add(new byte[] { 0, 1, 2, 3, 4, 5 }.RentThisData(), (6, 63504931));
-            map.Add(new byte[] { 6, 7, 8, 9, 0, 1 }.RentThisData(), (6, unchecked((int)97180294697L)));
-            map.Add(new byte[] { 255, 255, 255, 0xE1 }.RentThisData(), (4, 1));
-
-            foreach (KeyValuePair<byte[], (int, int)> item in map)
+            var map = new Dictionary<IByteBuffer, int> // buffer -> expected hashcode for the buffer data
             {
-                var bytes = item.Key;
-                var length = item.Value.Item1;
-                var expectedHashCode = item.Value.Item2;
-                
-                IByteBuffer buffer = WrappedBuffer(bytes, offset: 0, length: length);
+                { WrappedBuffer(EmptyBytes), 1 },
+                { new byte[] { 1 }.WrapWithRenting(length: 1), 32 },
+                { new byte[] { 2 }.WrapWithRenting(length: 1), 33 },
+                { new byte[] { 0, 1 }.WrapWithRenting(length: 2), 962 },
+                { new byte[] { 1, 2 }.WrapWithRenting(length: 2), 994 },
+                { new byte[] { 0, 1, 2, 3, 4, 5 }.WrapWithRenting(length: 6), 63504931 },
+                { new byte[] { 6, 7, 8, 9, 0, 1 }.WrapWithRenting(length: 6), unchecked((int)97180294697L) },
+                { new byte[] { 255, 255, 255, 0xE1 }.WrapWithRenting(length: 4), 1 }
+            };
+
+            foreach (var item in map)
+            {
+                var buffer = item.Key;
+                var expectedHashCode = item.Value;
                 Assert.Equal(expectedHashCode, ByteBufferUtil.HashCode(buffer));
                 buffer.Release();
             }
@@ -101,64 +99,64 @@ namespace DotNetty.Buffers.Tests
         public void Equals1()
         {
             // Different length.
-            IByteBuffer a = WrappedBuffer(new byte[] { 1 });
-            IByteBuffer b = WrappedBuffer(new byte[] { 1, 2 });
+            IByteBuffer a = new byte[] { 1 }.WrapWithRenting(0, 1);
+            IByteBuffer b = new byte[] { 1, 2 }.WrapWithRenting(0, 2);
             Assert.False(ByteBufferUtil.Equals(a, b));
-            a.ReleaseSafely();
-            b.ReleaseSafely();
+            a.Release();
+            b.Release();
 
             // Same content, same firstIndex, short length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3 });
-            b = WrappedBuffer(new byte[] { 1, 2, 3 });
+            a = new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3);
+            b = new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3);
             Assert.True(ByteBufferUtil.Equals(a, b));
-            a.ReleaseSafely();
-            b.ReleaseSafely();
+            a.Release();
+            b.Release();
 
             // Same content, different firstIndex, short length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3 });
-            b = WrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 1, 3);
+            a = new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3);
+            b = new byte[] { 0, 1, 2, 3, 4 }.WrapWithRenting(offset: 1, length: 3);
             Assert.True(ByteBufferUtil.Equals(a, b));
-            a.ReleaseSafely();
-            b.ReleaseSafely();
+            a.Release();
+            b.Release();
 
             // Different content, same firstIndex, short length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3 });
-            b = WrappedBuffer(new byte[] { 1, 2, 4 });
+            a = new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3);
+            b = new byte[] { 1, 2, 4 }.WrapWithRenting(length: 3);
             Assert.False(ByteBufferUtil.Equals(a, b));
-            a.ReleaseSafely();
-            b.ReleaseSafely();
+            a.Release();
+            b.Release();
 
             // Different content, different firstIndex, short length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3 });
-            b = WrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 1, 3);
+            a = new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3);
+            b = new byte[] { 0, 1, 2, 4, 5 }.WrapWithRenting(offset: 1, length: 3);
             Assert.False(ByteBufferUtil.Equals(a, b));
-            a.ReleaseSafely();
-            b.ReleaseSafely();
+            a.Release();
+            b.Release();
 
             // Same content, same firstIndex, long length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }.RentThisData());
-            b = WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }.RentThisData());
+            a = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }.WrapWithRenting();
+            b = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }.WrapWithRenting();
             Assert.True(ByteBufferUtil.Equals(a, b));
             a.Release();
             b.Release();
 
             // Same content, different firstIndex, long length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.RentThisData(), offset: 0, length: 10);
-            b = WrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }.RentThisData(), 1, 10);
+            a = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.WrapWithRenting(length: 10);
+            b = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }.WrapWithRenting(offset: 1, length: 10);
             Assert.True(ByteBufferUtil.Equals(a, b));
             a.Release();
             b.Release();
 
             // Different content, same firstIndex, long length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.RentThisData());
-            b = WrappedBuffer(new byte[] { 1, 2, 3, 4, 6, 7, 8, 5, 9, 10 }.RentThisData());
+            a = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.WrapWithRenting();
+            b = new byte[] { 1, 2, 3, 4, 6, 7, 8, 5, 9, 10 }.WrapWithRenting();
             Assert.False(ByteBufferUtil.Equals(a, b));
             a.Release();
             b.Release();
 
             // Different content, different firstIndex, long length.
-            a = WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.RentThisData(), offset: 0, length: 10);
-            b = WrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }.RentThisData(), 1, 10);
+            a = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.WrapWithRenting(length: 10);
+            b = new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }.WrapWithRenting(offset: 1, length: 10);
             Assert.False(ByteBufferUtil.Equals(a, b));
             a.Release();
             b.Release();
@@ -169,22 +167,22 @@ namespace DotNetty.Buffers.Tests
         {
             IList<IByteBuffer> expected = new List<IByteBuffer>();
             
-            expected.Add(WrappedBuffer(new byte[] { 1 }));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2 }));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }));
-            expected.Add(WrappedBuffer(new byte[] { 2 }));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3 }));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 }));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4 }, 1, 1));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4 }, 2, 2));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 1, 10));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 2, 12));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5 }, 2, 1));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5 }, 3, 2));
-            expected.Add(WrappedBuffer(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 2, 10));
-            expected.Add(WrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, 3, 12));
+            expected.Add(new byte[] { 1 }.WrapWithRenting(length: 1));
+            expected.Add(new byte[] { 1, 2 }.WrapWithRenting(length: 2));
+            expected.Add(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.WrapWithRenting(length: 10));
+            expected.Add(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }.WrapWithRenting(length: 12));
+            expected.Add(new byte[] { 2 }.WrapWithRenting(length: 1));
+            expected.Add(new byte[] { 2, 3 }.WrapWithRenting(length: 2));
+            expected.Add(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }.WrapWithRenting(length: 10));
+            expected.Add(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 }.WrapWithRenting(length: 12));
+            expected.Add(new byte[] { 2, 3, 4 }.WrapWithRenting(offset: 1, length: 1));
+            expected.Add(new byte[] { 1, 2, 3, 4 }.WrapWithRenting(offset: 2, length: 2));
+            expected.Add(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }.WrapWithRenting(offset: 1, length: 10));
+            expected.Add(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }.WrapWithRenting(offset: 2, length: 12));
+            expected.Add(new byte[] { 2, 3, 4, 5 }.WrapWithRenting(offset: 2, length: 1));
+            expected.Add(new byte[] { 1, 2, 3, 4, 5 }.WrapWithRenting(offset: 3, length: 2));
+            expected.Add(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }.WrapWithRenting(offset: 2, length: 10));
+            expected.Add(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }.WrapWithRenting(offset: 3, length: 12));
 
             for (int i = 0; i < expected.Count; i++)
             {
@@ -206,7 +204,7 @@ namespace DotNetty.Buffers.Tests
             }
             foreach (IByteBuffer buffer in expected)
             {
-                buffer.ReleaseSafely();
+                buffer.Release();
             }
         }
 
@@ -264,28 +262,17 @@ namespace DotNetty.Buffers.Tests
         [Fact]
         public void WrappedBuffers()
         {
-            //Assert.Equal(
-            //    WrappedBuffer(new byte[] { 1, 2, 3 }),
-            //    WrappedBuffer(new byte[][] { new byte[] { 1, 2, 3 } }));
-
-            //Assert.Equal(
-            //    WrappedBuffer(new byte[] { 1, 2, 3 }),
-            //    this.FreeLater(WrappedBuffer(
-            //        new byte[] { 1 }, 
-            //        new byte[] { 2 }, 
-            //        new byte[] { 3 })));
-
             Assert.Equal(
-                WrappedBuffer(new byte[] { 1, 2, 3 }.RentThisData(), offset: 0, length: 3),
-                WrappedBuffer(new [] { WrappedBuffer(new byte[] { 1, 2, 3 }.RentThisData(), offset: 0, length: 3) })
+                new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3),
+                WrappedBuffer(new [] { new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3) })
             );
 
             Assert.Equal(
-                WrappedBuffer(new byte[] { 1, 2, 3 }.RentThisData(), offset: 0, length: 3),
+                new byte[] { 1, 2, 3 }.WrapWithRenting(length: 3),
                 this.FreeLater(WrappedBuffer(
-                    WrappedBuffer(new byte[] { 1 }.RentThisData(), offset: 0, length: 1),
-                    WrappedBuffer(new byte[] { 2 }.RentThisData(), offset: 0, length: 1), 
-                    WrappedBuffer(new byte[] { 3 }.RentThisData(), offset: 0, length: 1)
+                    new byte[] { 1 }.WrapWithRenting(length: 1),
+                    new byte[] { 2 }.WrapWithRenting(length: 1), 
+                    new byte[] { 3 }.WrapWithRenting(length: 1)
                 ))
             );
         }
@@ -364,17 +351,6 @@ namespace DotNetty.Buffers.Tests
         [Fact]
         public void CopiedBuffers()
         {
-            //Assert.Equal(
-            //    WrappedBuffer(new byte[] { 1, 2, 3 }),
-            //    CopiedBuffer(new byte[][] { new byte[] { 1, 2, 3 } }));
-
-            //Assert.Equal(
-            //    WrappedBuffer(new byte[] { 1, 2, 3 }),
-            //    CopiedBuffer(
-            //        new byte[] { 1 }, 
-            //        new byte[] { 2 }, 
-            //        new byte[] { 3 }));
-
             Assert.Equal(
                 WrappedBuffer(new byte[] { 1, 2, 3 }),
                 CopiedBuffer(new [] { WrappedBuffer(new byte[] { 1, 2, 3 }) }));
@@ -392,14 +368,15 @@ namespace DotNetty.Buffers.Tests
         {
             Assert.Equal("", ByteBufferUtil.HexDump(Empty));
 
-            IByteBuffer buffer = WrappedBuffer(new byte[] { 0x12, 0x34, 0x56 }.RentThisData(), offset: 0, length: 3);
+            IByteBuffer buffer = new byte[] { 0x12, 0x34, 0x56 }.WrapWithRenting(length: 3);
             Assert.Equal("123456", ByteBufferUtil.HexDump(buffer));
             buffer.Release();
 
-            buffer = WrappedBuffer(new byte[]{
+            buffer = WrappedBuffer(new byte[]
+            {
                 0x12, 0x34, 0x56, 0x78,
                 0x90, 0xAB, 0xCD, 0xEF
-            }.RentThisData(), offset: 0, length: 8);
+            }.WrapWithRenting(length: 8));
             Assert.Equal("1234567890abcdef", ByteBufferUtil.HexDump(buffer));
         }
 
@@ -603,31 +580,22 @@ namespace DotNetty.Buffers.Tests
     
     static class ArrayPoolingHelpers
     {
-        public static byte[] RentThisData(this byte[] arr)
+        public static IByteBuffer WrapWithRenting(this byte[] arr, int offset = 0, int? length = null)
+        {
+            var rentedArr = arr.RentThisData();
+            length ??= arr.Length;
+            return WrappedBuffer(rentedArr, offset, length.Value);
+        }
+        
+        private static T[] RentThisData<T>(this T[] arr)
         {          
-            var rentedArr = ArrayPool<byte>.Shared.Rent(arr.Length);
+            var rentedArr = ArrayPool<T>.Shared.Rent(arr.Length);
             for (int i = 0; i < arr.Length; i++)
             {
                 rentedArr[i] = arr[i];
             }
 
             return rentedArr;
-        }
-        
-        public static bool ReleaseSafely(this IReferenceCounted buffer)
-        {
-            try
-            {
-                return buffer.Release();
-            }
-            catch (System.ArgumentException ex) when (ex.Message.Contains("The buffer is not associated with this pool and may not be returned to it"))
-            {
-                // ignoring because it's test.
-                // It happens when instead of using ArrayPool.Rent() (via buffer or separately) dev passes non-rented array to the buffer (i.e. `new byte[3] { ... }`)
-                
-                // we dont really care if that happens in the test, but that is not covered with Exception
-                return false;
-            }
         } 
     }
 }


### PR DESCRIPTION
Tests are not renting the initial array on which the char sequence is attempted to be set (`var array = new byte[1];`).
And during `ArrayPooledHeapByteBuffer`'s or `ArrayPooledUnsafeDirectByteBuffer`'s `.Release()` invocation, that array is attempted to be returned to the underlying array pool, resulting in exception as below:
```
System.ArgumentException : The buffer is not associated with this pool and may not be returned to it. (Parameter 'array')
 at System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1.Return(T[] array, Boolean clearArray)
   at DotNetty.Buffers.ArrayPooledByteBuffer.FreeArray(Byte[] bytes) in D:\a\1\s\src\DotNetty.Buffers\ArrayPooledByteBuffer.cs:line 93
```

I have adjusted the test to actually rent the array, which will result in successful return to the pool. I also discovered, that I cannot rent the array of length 1, because this is the [internal implementation of ArrayPool](https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs,15) - it will return **at least** length of 16. Because of that I adjusted the charSequence to be more than of 16 symbols, and test is still throwing the excepted exception, but also correctly returns the rented array back to the pool.