### PR TITLE
Make SingleThreadEventLoop._emptyEvent spin count configurable

### DIFF
--- a/src/DotNetty.Transport/Channels/MultithreadEventLoopGroup.cs
+++ b/src/DotNetty.Transport/Channels/MultithreadEventLoopGroup.cs
@@ -146,8 +146,8 @@ namespace DotNetty.Transport.Channels
 
         /// <summary>Creates a new instance of <see cref="MultithreadEventLoopGroup"/>.</summary>
         public MultithreadEventLoopGroup(int nThreads, IThreadFactory threadFactory, IEventExecutorChooserFactory<SingleThreadEventLoop> chooserFactory,
-            IRejectedExecutionHandler rejectedHandler, TimeSpan breakoutInterval)
-            : base(nThreads, chooserFactory, group => new SingleThreadEventLoop(group, threadFactory, rejectedHandler, breakoutInterval))
+            IRejectedExecutionHandler rejectedHandler, TimeSpan breakoutInterval, int emptyTaskQueueSpinCount = 1)
+            : base(nThreads, chooserFactory, group => new SingleThreadEventLoop(group, threadFactory, rejectedHandler, breakoutInterval, emptyTaskQueueSpinCount))
         {
         }
     }

--- a/src/DotNetty.Transport/Channels/SingleThreadEventLoop.cs
+++ b/src/DotNetty.Transport/Channels/SingleThreadEventLoop.cs
@@ -81,10 +81,10 @@ namespace DotNetty.Transport.Channels
         {
         }
 
-        public SingleThreadEventLoop(IEventLoopGroup parent, IThreadFactory threadFactory, IRejectedExecutionHandler rejectedHandler, TimeSpan breakoutInterval)
+        public SingleThreadEventLoop(IEventLoopGroup parent, IThreadFactory threadFactory, IRejectedExecutionHandler rejectedHandler, TimeSpan breakoutInterval, int emptyTaskQueueSpinCount = 1)
             : base(parent, threadFactory, false, int.MaxValue, rejectedHandler)
         {
-            _emptyEvent = new ManualResetEventSlim(false, 1);
+            _emptyEvent = new ManualResetEventSlim(false, emptyTaskQueueSpinCount);
             _breakoutNanosInterval = PreciseTime.ToDelayNanos(breakoutInterval);
             Start();
         }


### PR DESCRIPTION
Under high load, higher spinCount provides better performance