### PR TITLE
Add net8 and net9 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ExamplesTargetFramework>net6.0</ExamplesTargetFramework>
+    <ExamplesTargetFramework>net9.0</ExamplesTargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SourceRoot)/build/DotNetty.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -135,14 +135,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFrameworkIdentifier)|$(Platform)'=='Debug|.NETCoreApp|AnyCPU'">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>5</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFrameworkIdentifier)|$(Platform)'=='Release|.NETCoreApp|AnyCPU'">
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <ErrorReport>prompt</ErrorReport>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <DefineConstants>$(DefineConstants);NETCOREAPP_2_X_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,8 +47,8 @@
     <ImportLibs>netcore</ImportLibs>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net6.0-windows' or '$(TargetFramework)' == 'net6.0-windows7.0' ">
-    <DefineConstants>$(DefineConstants);net60;NETCOREAPP;NETCOREAPP_2_0_GREATER;NETCOREAPP_2_1_GREATER;NETCOREAPP_2_X_GREATER;NETCOREAPP_3_0_GREATER;NETCOREAPP_3_1_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+    <DefineConstants>$(DefineConstants);NETCOREAPP_2_0_GREATER;NETCOREAPP_2_1_GREATER;NETCOREAPP_2_X_GREATER;NETCOREAPP_3_0_GREATER;NETCOREAPP_3_1_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,6 +45,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImportLibs>netcore</ImportLibs>
+    <TargetFrameworkIdentifier>$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))</TargetFrameworkIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <DefineConstants>$(DefineConstants);NETCOREAPP_2_0_GREATER;NETCOREAPP_2_1_GREATER;NETCOREAPP_2_X_GREATER;NETCOREAPP_3_0_GREATER;NETCOREAPP_3_1_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP_2_1_GREATER;NETCOREAPP_2_X_GREATER;NETCOREAPP_3_1_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
 
   <!-- Common compile parameters -->
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <!--<LangVersion>latest</LangVersion>-->
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <DefineConstants>$(DefineConstants);NETCOREAPP_2_1_GREATER;NETCOREAPP_2_X_GREATER;NETCOREAPP_3_1_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP_2_X_GREATER;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NET_4_0_GREATER;NET_4_5_GREATER;NET_4_6_GREATER</DefineConstants>

--- a/build.fsx
+++ b/build.fsx
@@ -45,7 +45,7 @@ let incrementalistReport = output @@ "incrementalist.txt"
 
 // Configuration values for tests
 let testNetFrameworkVersion = "net471"
-let testNetVersion = "net6.0"
+let testNetVersion = "9.0"
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"

--- a/build.fsx
+++ b/build.fsx
@@ -215,7 +215,7 @@ Target "RunTests" (fun _ ->
                                        -- "./test/*.Tests/DotNetty.End2End.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
 
-        let testNetVersions = [ "net6.0" ]
+        let testNetVersions = [ "net8.0" ]
     
         let runSingleProject project testNetVersion =
             let arguments =

--- a/build.fsx
+++ b/build.fsx
@@ -215,7 +215,7 @@ Target "RunTests" (fun _ ->
                                        -- "./test/*.Tests/DotNetty.End2End.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
 
-        let testNetVersions = [ "net9.0"; "net8.0"; "net6.0" ]
+        let testNetVersions = [ "net6.0" ]
     
         let runSingleProject project testNetVersion =
             let arguments =

--- a/build.fsx
+++ b/build.fsx
@@ -45,7 +45,6 @@ let incrementalistReport = output @@ "incrementalist.txt"
 
 // Configuration values for tests
 let testNetFrameworkVersion = "net471"
-let testNetVersion = "9.0"
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"
@@ -183,16 +182,6 @@ type Runtime =
     | Net
     | NetFramework
 
-let getTestAssembly runtime project =
-    let assemblyPath = match runtime with
-                        | NetFramework -> !! ("test" @@ "**" @@ "bin" @@ "Debug" @@ "win-x64" @@ testNetFrameworkVersion @@ fileNameWithoutExt project + ".dll")
-                        | Net -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetVersion @@ fileNameWithoutExt project + ".dll")
-
-    if Seq.isEmpty assemblyPath then
-        None
-    else
-        Some (assemblyPath |> Seq.head)
-
 module internal ResultHandling =
     let (|OK|Failure|) = function
         | 0 -> OK
@@ -225,8 +214,10 @@ Target "RunTests" (fun _ ->
                                        -- "./test/*.Tests/DotNetty.Handlers.Proxy.Tests.csproj"
                                        -- "./test/*.Tests/DotNetty.End2End.Tests.csproj"
             rawProjects |> Seq.choose filterProjects
-     
-        let runSingleProject project =
+
+        let testNetVersions = [ "net9.0"; "net8.0"; "net6.0" ]
+    
+        let runSingleProject project testNetVersion =
             let arguments =
                 match (hasTeamCity) with
                 | true -> (sprintf "test -c %s --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s -- RunConfiguration.TargetPlatform=x64 --results-directory \"%s\" -- -parallel none -teamcity" configuration testNetVersion outputTests)
@@ -240,7 +231,10 @@ Target "RunTests" (fun _ ->
             ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
 
         CreateDir outputTests
-        projects |> Seq.iter (runSingleProject)
+
+        for project in projects do
+            for testNetVersion in testNetVersions do
+                runSingleProject project testNetVersion        
 )
 
 Target "RunTestsNetFx471" (fun _ ->    

--- a/build/templates/install-dotnet.yaml
+++ b/build/templates/install-dotnet.yaml
@@ -4,3 +4,13 @@ steps:
   inputs:
     packageType: sdk
     version: 6.x
+- task: UseDotNet@2
+  displayName: 'Install SDK 8.x'
+  inputs:
+    packageType: sdk
+    version: 8.x
+- task: UseDotNet@2
+  displayName: 'Install SDK 9.x'
+  inputs:
+    packageType: sdk
+    version: 9.x

--- a/examples/Http2Helloworld.FrameServer/Http2OrHttpHandler.cs
+++ b/examples/Http2Helloworld.FrameServer/Http2OrHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP_2_0_GREATER
+﻿#if NET6_0_OR_GREATER
 namespace Http2Helloworld.FrameServer
 {
     using DotNetty.Codecs.Http;

--- a/examples/Http2Helloworld.MultiplexServer/Http2OrHttpHandler.cs
+++ b/examples/Http2Helloworld.MultiplexServer/Http2OrHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP_2_0_GREATER
+﻿#if NET6_0_OR_GREATER
 namespace Http2Helloworld.MultiplexServer
 {
     using DotNetty.Codecs.Http;

--- a/examples/Http2Helloworld.Server/Http2OrHttpHandler.cs
+++ b/examples/Http2Helloworld.Server/Http2OrHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP_2_0_GREATER
+﻿#if NET6_0_OR_GREATER
 namespace Http2Helloworld.Server
 {
     using DotNetty.Codecs.Http;

--- a/examples/Http2Tiles/Http2OrHttpHandler.cs
+++ b/examples/Http2Tiles/Http2OrHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP_2_0_GREATER
+﻿#if NET6_0_OR_GREATER
 namespace Http2Tiles
 {
     using DotNetty.Codecs.Http;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <DeveloperBuildTfms>netstandard2.0</DeveloperBuildTfms>
     <StandardTfms>$(DeveloperBuildTfms)</StandardTfms>
-    <DotNetTfms>net6.0;net8.0;net9.0</DotNetTfms>
+    <NetCoreAppTfms>net6.0;net8.0;net9.0</NetCoreAppTfms>
     <StandardTfms Condition=" '$(OS)' == 'Windows_NT' ">$(StandardTfms);net471</StandardTfms>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <DeveloperBuildTfms>netstandard2.0</DeveloperBuildTfms>
     <StandardTfms>$(DeveloperBuildTfms)</StandardTfms>
+    <DotNetTfms>net6.0;net8.0;net9.0</DotNetTfms>
     <StandardTfms Condition=" '$(OS)' == 'Windows_NT' ">$(StandardTfms);net471</StandardTfms>
   </PropertyGroup>
 

--- a/src/DotNetty.Buffers/ByteBufferUtil.Utf8.cs
+++ b/src/DotNetty.Buffers/ByteBufferUtil.Utf8.cs
@@ -118,7 +118,7 @@ namespace DotNetty.Buffers
                     default:
                         if (seq is IHasUtf16Span hasUtf16)
                         {
-#if NETCOREAPP_2_X_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                             var utf16Span = hasUtf16.Utf16Span[start..end];
 #else
                             var utf16Span = hasUtf16.Utf16Span.Slice(start, end - start);
@@ -169,7 +169,7 @@ namespace DotNetty.Buffers
         {
             if (value is IHasUtf16Span hasUtf16)
             {
-#if NETCOREAPP_2_X_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 var utf16Span = hasUtf16.Utf16Span[start..end];
 #else
                 var utf16Span = hasUtf16.Utf16Span.Slice(start, end - start);

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Buffers</RootNamespace>
     <AssemblyName>SpanNetty.Buffers</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Buffers</RootNamespace>
     <AssemblyName>SpanNetty.Buffers</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/DotNetty.Buffers/Reader/ByteBufferReader.Helper.cs
+++ b/src/DotNetty.Buffers/Reader/ByteBufferReader.Helper.cs
@@ -39,7 +39,7 @@ namespace DotNetty.Buffers
         private const int IndexBitMask = ~FlagBitMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void GetFirstSpan(in ReadOnlySequence<byte> buffer, out ReadOnlySpan<byte> first, out SequencePosition next)
+        internal static void GetFirstSpan(scoped in ReadOnlySequence<byte> buffer, out ReadOnlySpan<byte> first, out SequencePosition next)
         {
             first = default;
             next = default;

--- a/src/DotNetty.Buffers/Reader/ByteBufferReader.Search.cs
+++ b/src/DotNetty.Buffers/Reader/ByteBufferReader.Search.cs
@@ -371,7 +371,7 @@ namespace DotNetty.Buffers
         /// <param name="advancePastDelimiter">True to move past the first found instance of any of the given <paramref name="delimiters"/>.</param>
         /// <returns>True if any of the <paramref name="delimiters"/> were found.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryReadToAny(out ReadOnlySpan<byte> span, in ReadOnlySpan<byte> delimiters, bool advancePastDelimiter = true)
+        public bool TryReadToAny(out ReadOnlySpan<byte> span, scoped in ReadOnlySpan<byte> delimiters, bool advancePastDelimiter = true)
         {
             ReadOnlySpan<byte> remaining = UnreadSpan;
 #if NET
@@ -393,7 +393,7 @@ namespace DotNetty.Buffers
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool TryReadToAnySlow(out ReadOnlySpan<byte> span, in ReadOnlySpan<byte> delimiters, bool advancePastDelimiter)
+        private bool TryReadToAnySlow(out ReadOnlySpan<byte> span, scoped in ReadOnlySpan<byte> delimiters, bool advancePastDelimiter)
         {
             if (!TryReadToAnyInternal(out ReadOnlySequence<byte> sequence, delimiters, advancePastDelimiter, _currentSpan.Length - _currentSpanIndex))
             {

--- a/src/DotNetty.Buffers/Reader/ByteBufferReader.cs
+++ b/src/DotNetty.Buffers/Reader/ByteBufferReader.cs
@@ -40,7 +40,7 @@ namespace DotNetty.Buffers
         private SequencePosition _currentPosition;
         private SequencePosition _nextPosition;
         private bool _moreData;
-        private readonly long _length;
+        private long _length;
 
         private readonly ReadOnlySequence<byte> _sequence;
         private ReadOnlySpan<byte> _currentSpan;
@@ -59,7 +59,7 @@ namespace DotNetty.Buffers
             _currentPosition = sequence.Start;
             _length = -1;
 
-            ByteBufferReaderHelper.GetFirstSpan(sequence, out ReadOnlySpan<byte> first, out _nextPosition);
+            ByteBufferReaderHelper.GetFirstSpan(in sequence, out ReadOnlySpan<byte> first, out _nextPosition);
             _currentSpan = first;
             _moreData = (uint)first.Length > 0u;
 
@@ -81,7 +81,7 @@ namespace DotNetty.Buffers
             _currentPosition = sequence.Start;
             _length = -1;
 
-            ByteBufferReaderHelper.GetFirstSpan(sequence, out ReadOnlySpan<byte> first, out _nextPosition);
+            ByteBufferReaderHelper.GetFirstSpan(in sequence, out ReadOnlySpan<byte> first, out _nextPosition);
             _currentSpan = first;
             _moreData = (uint)first.Length > 0u;
 
@@ -147,7 +147,7 @@ namespace DotNetty.Buffers
         public readonly long Remaining => Length - _consumed;
 
         /// <summary>Count of <see cref="byte"/> in the reader's <see cref="Sequence"/>.</summary>
-        public readonly long Length
+        public long Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -155,7 +155,14 @@ namespace DotNetty.Buffers
                 if (_length < 0L)
                 {
                     // Cast-away readonly to initialize lazy field
-                    Volatile.Write(ref Unsafe.AsRef(_length), Sequence.Length);
+                    Volatile.Write(ref Unsafe.AsRef(
+#if NET8_0_OR_GREATER
+                        ref
+#else
+                        in
+#endif
+                        _length), Sequence.Length);
+   
                 }
                 return _length;
             }

--- a/src/DotNetty.Codecs.Http/Cookies/DefaultCookie.cs
+++ b/src/DotNetty.Codecs.Http/Cookies/DefaultCookie.cs
@@ -126,7 +126,7 @@ namespace DotNetty.Codecs.Http.Cookies
             }
 
             if (!string.Equals(_name, other.Name
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     ))
 #else
                     , StringComparison.Ordinal))
@@ -147,7 +147,7 @@ namespace DotNetty.Codecs.Http.Cookies
                 return false;
             }
             else if (!string.Equals(_path, other.Path
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     ))
 #else
                     , StringComparison.Ordinal))

--- a/src/DotNetty.Codecs.Http/HttpObjectDecoder.cs
+++ b/src/DotNetty.Codecs.Http/HttpObjectDecoder.cs
@@ -781,7 +781,7 @@ namespace DotNetty.Codecs.Http
                         for (int idx = 0; idx < contentLengthFields.Count; idx++)
                         {
                             string[] tokens = contentLengthFields[idx].ToString().Split(
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                                 StringUtil.Comma
 #else
                                 s_commaSeparator

--- a/src/DotNetty.Codecs.Http/HttpVersion.cs
+++ b/src/DotNetty.Codecs.Http/HttpVersion.cs
@@ -211,7 +211,7 @@ namespace DotNetty.Codecs.Http
                 return this.minorVersion == that.minorVersion
                     && this.majorVersion == that.majorVersion
                     && string.Equals(this.protocolName, that.protocolName
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         );
 #else
                         , StringComparison.Ordinal);
@@ -229,7 +229,7 @@ namespace DotNetty.Codecs.Http
                 && this.minorVersion == other.minorVersion
                 && this.majorVersion == other.majorVersion
                 && string.Equals(this.protocolName, other.protocolName
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     );
 #else
                     , StringComparison.Ordinal);

--- a/src/DotNetty.Codecs.Http/Multipart/HttpPostMultipartRequestDecoder.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/HttpPostMultipartRequestDecoder.cs
@@ -821,7 +821,7 @@ namespace DotNetty.Codecs.Http.Multipart
                     ThrowHelper.ThrowErrorDataDecoderException(e);
                 }
                 if (string.Equals(code, HttpPostBodyUtil.TransferEncodingMechanism.Bit7.Value
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     ))
 #else
                     , StringComparison.Ordinal))
@@ -830,7 +830,7 @@ namespace DotNetty.Codecs.Http.Multipart
                     localCharset = Encoding.ASCII;
                 }
                 else if (string.Equals(code, HttpPostBodyUtil.TransferEncodingMechanism.Bit8.Value
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     ))
 #else
                     , StringComparison.Ordinal))
@@ -840,7 +840,7 @@ namespace DotNetty.Codecs.Http.Multipart
                     mechanism = HttpPostBodyUtil.TransferEncodingMechanism.Bit8;
                 }
                 else if (string.Equals(code, HttpPostBodyUtil.TransferEncodingMechanism.Binary.Value
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     ))
 #else
                     , StringComparison.Ordinal))

--- a/src/DotNetty.Codecs.Http/Multipart/HttpPostRequestEncoder.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/HttpPostRequestEncoder.cs
@@ -425,7 +425,7 @@ namespace DotNetty.Codecs.Http.Multipart
                 if (this.duringMixedMode)
                 {
                     if (this.currentFileUpload is object && string.Equals(this.currentFileUpload.Name, fileUpload.Name
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         ))
 #else
                         , StringComparison.Ordinal))
@@ -459,7 +459,7 @@ namespace DotNetty.Codecs.Http.Multipart
                 {
                     if (this.encoderMode != EncoderMode.HTML5 && this.currentFileUpload is object
                         && string.Equals(this.currentFileUpload.Name, fileUpload.Name
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                             ))
 #else
                             , StringComparison.Ordinal))
@@ -600,7 +600,7 @@ namespace DotNetty.Codecs.Http.Multipart
                 string contentTransferEncoding = fileUpload.ContentTransferEncoding;
                 if (contentTransferEncoding is object
                     && string.Equals(contentTransferEncoding, HttpPostBodyUtil.TransferEncodingMechanism.Binary.Value
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         ))
 #else
                         , StringComparison.Ordinal))

--- a/src/DotNetty.Codecs.Http/Utilities/HttpEncoderUtility.cs
+++ b/src/DotNetty.Codecs.Http/Utilities/HttpEncoderUtility.cs
@@ -100,7 +100,7 @@ namespace DotNetty.Codecs.Http.Utilities
         }
 
         //  Helper to encode spaces only
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         internal static string UrlEncodeSpaces(string str) => str is object && str.Contains(' ') ? str.Replace(" ", "%20") : str;
 #else
         internal static string UrlEncodeSpaces(string str) => str is object && str.IndexOf(' ') >= 0 ? str.Replace(" ", "%20") : str;

--- a/src/DotNetty.Codecs.Http/Utilities/HttpUtility.Url.cs
+++ b/src/DotNetty.Codecs.Http/Utilities/HttpUtility.Url.cs
@@ -200,7 +200,7 @@ namespace DotNetty.Codecs.Http.Utilities
             int i = value.IndexOf('?');
             if (i >= 0)
             {
-//#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+//#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
 //                return string.Concat(UrlPathEncodeImpl(value.Substring(0, i)), value.AsSpan(i));
 //#else
                 return UrlPathEncodeImpl(value.Substring(0, i)) + value.Substring(i);

--- a/src/DotNetty.Codecs.Http/WebSockets/Extensions/Compression/PerMessageDeflateServerExtensionHandshaker.cs
+++ b/src/DotNetty.Codecs.Http/WebSockets/Extensions/Compression/PerMessageDeflateServerExtensionHandshaker.cs
@@ -228,7 +228,7 @@ namespace DotNetty.Codecs.Http.WebSockets.Extensions.Compression
         [MethodImpl(InlineMethod.AggressiveInlining)]
         internal static bool IsPerMessageDeflateExtension(string name)
         {
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
             if (string.Equals(PerMessageDeflateExtension, name)) { return true; }
 #else
             if (string.Equals(PerMessageDeflateExtension, name, StringComparison.Ordinal)) { return true; }

--- a/src/DotNetty.Codecs.Http/WebSockets/WebSocketClientHandshaker.cs
+++ b/src/DotNetty.Codecs.Http/WebSockets/WebSocketClientHandshaker.cs
@@ -252,7 +252,7 @@ namespace DotNetty.Codecs.Http.WebSockets
                 foreach (string protocol in expectedProtocol.Split(','))
                 {
                     if (string.Equals(protocol.Trim(), receivedProtocol
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         ))
 #else
                         , StringComparison.Ordinal))
@@ -549,7 +549,7 @@ namespace DotNetty.Codecs.Http.WebSockets
             }
             if (port == HttpScheme.Https.Port)
             {
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 return string.Equals(HttpScheme.Https.Name.ToString(), scheme)
                     || string.Equals(WebSocketScheme.WSS.Name.ToString(), scheme)
 #else

--- a/src/DotNetty.Codecs.Http/WebSockets/WebSocketServerHandshaker.cs
+++ b/src/DotNetty.Codecs.Http/WebSockets/WebSocketServerHandshaker.cs
@@ -352,7 +352,7 @@ namespace DotNetty.Codecs.Http.WebSockets
 
                 foreach (string supportedSubprotocol in _subprotocols)
                 {
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     if (string.Equals(SubProtocolWildcard, supportedSubprotocol)
                         || string.Equals(requestedSubprotocol, supportedSubprotocol))
 #else

--- a/src/DotNetty.Codecs.Http/WebSockets/WebSocketServerProtocolHandshakeHandler.cs
+++ b/src/DotNetty.Codecs.Http/WebSockets/WebSocketServerProtocolHandshakeHandler.cs
@@ -132,7 +132,7 @@ namespace DotNetty.Codecs.Http.WebSockets
             return _serverConfig.CheckStartsWith
                 ? !req.Uri.StartsWith(websocketPath, StringComparison.Ordinal)
                 : !string.Equals(req.Uri, websocketPath
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     );
 #else
                     , StringComparison.Ordinal);

--- a/src/DotNetty.Codecs.Http/WebSockets/WebSocketUtil.cs
+++ b/src/DotNetty.Codecs.Http/WebSockets/WebSocketUtil.cs
@@ -36,7 +36,7 @@ namespace DotNetty.Codecs.Http.WebSockets
     using System.Security.Cryptography;
     using DotNetty.Common;
     using DotNetty.Common.Internal;
-#if !(NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER)
+#if !(NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER)
     using System.Runtime.CompilerServices;
 #endif
 
@@ -96,7 +96,7 @@ namespace DotNetty.Codecs.Http.WebSockets
                     (utf8Array = ArrayPool<byte>.Shared.Rent(maxLen));
                 var result = Base64.EncodeToUtf8(data, utf8Bytes, out _, out int bytesWritten);
                 Debug.Assert(result == OperationStatus.Done);
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 ReadOnlySpan<byte> base64Bytes = MemoryMarshal.CreateReadOnlySpan(ref MemoryMarshal.GetReference(utf8Bytes), bytesWritten);
 #else
                 ReadOnlySpan<byte> base64Bytes;

--- a/src/DotNetty.Codecs.Mqtt/MqttDecoder.cs
+++ b/src/DotNetty.Codecs.Mqtt/MqttDecoder.cs
@@ -255,7 +255,7 @@ namespace DotNetty.Codecs.Mqtt
         {
             string protocolName = DecodeString(buffer, ref remainingLength);
             if (!string.Equals(Util.ProtocolName, protocolName
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 ))
 #else
                 , StringComparison.Ordinal))

--- a/src/DotNetty.Codecs.Mqtt/Packets/SubscriptionRequest.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/SubscriptionRequest.cs
@@ -48,7 +48,7 @@ namespace DotNetty.Codecs.Mqtt.Packets
         {
             return QualityOfService == other.QualityOfService
                 && string.Equals(TopicFilter, other.TopicFilter
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     );
 #else
                     , StringComparison.Ordinal);

--- a/src/DotNetty.Common/Concurrency/AbstractExecutorService.cs
+++ b/src/DotNetty.Common/Concurrency/AbstractExecutorService.cs
@@ -116,18 +116,20 @@ namespace DotNetty.Common.Concurrency
             public void Run() => _action(_state);
         }
 
-        sealed class StateActionWithContextTaskQueueNode : IRunnable
+        public sealed class StateActionWithContextTaskQueueNode : IRunnable
         {
             readonly Action<object, object> _action;
             readonly object _context;
             readonly object _state;
-
+            
             public StateActionWithContextTaskQueueNode(Action<object, object> action, object context, object state)
             {
                 _action = action;
                 _context = context;
                 _state = state;
             }
+
+            public object State => _state;
 
             public void Run() => _action(_context, _state);
         }

--- a/src/DotNetty.Common/Concurrency/AbstractExecutorService.cs
+++ b/src/DotNetty.Common/Concurrency/AbstractExecutorService.cs
@@ -116,7 +116,7 @@ namespace DotNetty.Common.Concurrency
             public void Run() => _action(_state);
         }
 
-        public sealed class StateActionWithContextTaskQueueNode : IRunnable
+        sealed class StateActionWithContextTaskQueueNode : IRunnable
         {
             readonly Action<object, object> _action;
             readonly object _context;
@@ -128,8 +128,6 @@ namespace DotNetty.Common.Concurrency
                 _context = context;
                 _state = state;
             }
-
-            public object State => _state;
 
             public void Run() => _action(_context, _state);
         }

--- a/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
@@ -532,7 +532,10 @@ namespace DotNetty.Common.Concurrency
         [MethodImpl(InlineMethod.AggressiveInlining)]
         internal bool OfferTask(IRunnable task)
         {
-            if (IsShutdown) { Reject(); }
+            if (IsShutdown)
+            {
+                Reject(task);
+            }
 
             return _taskQueue.TryEnqueue(task);
         }

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Common</RootNamespace>
     <AssemblyName>SpanNetty.Common</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Common</RootNamespace>
     <AssemblyName>SpanNetty.Common</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -16,7 +16,7 @@
     <PackageTags>socket;tcp;protocol;netty;dotnetty;network</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">

--- a/src/DotNetty.Common/Internal/ASCIIUtility.Helpers.cs
+++ b/src/DotNetty.Common/Internal/ASCIIUtility.Helpers.cs
@@ -4,7 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Diagnostics;
 using System.Numerics;

--- a/src/DotNetty.Common/Internal/ASCIIUtility.cs
+++ b/src/DotNetty.Common/Internal/ASCIIUtility.cs
@@ -4,7 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Diagnostics;
 using System.Numerics;

--- a/src/DotNetty.Common/Internal/InlineMethod.cs
+++ b/src/DotNetty.Common/Internal/InlineMethod.cs
@@ -10,7 +10,7 @@ namespace DotNetty
 
         /// <summary>Value for lining method</summary>
         public const MethodImplOptions AggressiveOptimization =
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             MethodImplOptions.AggressiveOptimization;
 #else
             MethodImplOptions.AggressiveInlining;

--- a/src/DotNetty.Common/Internal/SpanHelpers.Byte.cs
+++ b/src/DotNetty.Common/Internal/SpanHelpers.Byte.cs
@@ -8,7 +8,7 @@ namespace DotNetty.Common.Internal
     using System.Numerics;
     using System.Runtime.CompilerServices;
     using DotNetty.Common.Utilities;
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
     using System.Runtime.Intrinsics;
     using System.Runtime.Intrinsics.X86;
 #endif
@@ -331,7 +331,7 @@ namespace DotNetty.Common.Internal
         {
             Debug.Assert(length >= 0);
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             return SharedConstants.TooBigOrNegative >= (uint)IndexOf(ref searchSpace, value, length);
 #else
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
@@ -494,7 +494,7 @@ namespace DotNetty.Common.Internal
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr lengthToExamine = (IntPtr)(void*)minLength;
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             if (Avx2.IsSupported)
             {
                 if ((byte*)lengthToExamine >= (byte*)Vector256<byte>.Count)
@@ -725,7 +725,7 @@ namespace DotNetty.Common.Internal
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr lengthToExamine = (IntPtr)length;
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
@@ -791,7 +791,7 @@ namespace DotNetty.Common.Internal
                 offset += 1;
             }
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true; and remain length is greater than Vector length.
             // However, we still have the redundant check to allow the JIT to see that the code is unreachable and eliminate it when the platform does not
             // have hardware accelerated. After processing Vector lengths we return to SequentialScan to finish any remaining.
@@ -999,7 +999,7 @@ namespace DotNetty.Common.Internal
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr lengthToExamine = (IntPtr)length;
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
@@ -1079,7 +1079,7 @@ namespace DotNetty.Common.Internal
                 offset += 1;
             }
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
             // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
             if (Avx2.IsSupported)
@@ -1240,7 +1240,7 @@ namespace DotNetty.Common.Internal
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr lengthToExamine = (IntPtr)length;
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
@@ -1320,7 +1320,7 @@ namespace DotNetty.Common.Internal
                 offset += 1;
             }
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             if (Avx2.IsSupported)
             {
                 if ((int)(byte*)offset < length)
@@ -3260,7 +3260,7 @@ namespace DotNetty.Common.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundByte(ulong match)
         {
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             if (Bmi1.X64.IsSupported)
             {
                 return (int)(Bmi1.X64.TrailingZeroCount(match) >> 3);
@@ -3272,7 +3272,7 @@ namespace DotNetty.Common.Internal
             var powerOfTwoFlag = match ^ (match - 1);
             // Shift all powers of two into the high byte and extract
             return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             }
 #endif
         }
@@ -3280,7 +3280,7 @@ namespace DotNetty.Common.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundByte(ulong match)
         {
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             return 7 - (BitOperations.LeadingZeroCount(match) >> 3);
 #else
             // Find the most significant byte that has its highest bit set
@@ -3323,7 +3323,7 @@ namespace DotNetty.Common.Internal
         private static unsafe Vector<byte> LoadVector(ref byte start, IntPtr offset)
             => Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector128<byte> LoadVector128(ref byte start, IntPtr offset)
             => Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
@@ -3337,7 +3337,7 @@ namespace DotNetty.Common.Internal
         private static unsafe IntPtr GetByteVectorSpanLength(IntPtr offset, int length)
             => (IntPtr)((length - (int)(byte*)offset) & ~(Vector<byte>.Count - 1));
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe IntPtr GetByteVector128SpanLength(IntPtr offset, int length)
             => (IntPtr)((length - (int)(byte*)offset) & ~(Vector128<byte>.Count - 1));
@@ -3354,7 +3354,7 @@ namespace DotNetty.Common.Internal
             return (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
         }
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe IntPtr UnalignedCountVector128(ref byte searchSpace)
         {

--- a/src/DotNetty.Common/Internal/SpanHelpers.Char.cs
+++ b/src/DotNetty.Common/Internal/SpanHelpers.Char.cs
@@ -7,7 +7,7 @@ namespace DotNetty.Common.Internal
     using System.Diagnostics;
     using System.Numerics;
     using System.Runtime.CompilerServices;
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
     using System.Runtime.Intrinsics;
     using System.Runtime.Intrinsics.X86;
 #endif
@@ -20,7 +20,7 @@ namespace DotNetty.Common.Internal
         {
             Debug.Assert(length >= 0);
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             int index = IndexOf(ref searchSpace, value, length);
             return SharedConstants.TooBigOrNegative >= (uint)index;
 #else
@@ -313,7 +313,7 @@ namespace DotNetty.Common.Internal
         {
             Debug.Assert(length >= 0);
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             nint offset = 0;
             nint lengthToExamine = length;
 
@@ -1453,7 +1453,7 @@ namespace DotNetty.Common.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundChar(ulong match)
         {
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             // TODO: Arm variants
             if (Bmi1.X64.IsSupported)
             {
@@ -1469,7 +1469,7 @@ namespace DotNetty.Common.Internal
                 // Shift all powers of two into the high byte and extract
                 return (int)((powerOfTwoFlag * XorPowerOfTwoToHighChar) >> 49);
             }
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             }
 #endif
         }
@@ -1502,7 +1502,7 @@ namespace DotNetty.Common.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundChar(ulong match)
         {
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             return 3 - (BitOperations.LeadingZeroCount(match) >> 4);
 #else
             // Find the most significant char that has its highest bit set
@@ -1516,7 +1516,7 @@ namespace DotNetty.Common.Internal
 #endif
         }
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref char Add(ref char source, nint elementOffset)
             => ref Unsafe.Add(ref source, (IntPtr)elementOffset);

--- a/src/DotNetty.Common/Internal/TextEncodings.Utf16.NetCore.cs
+++ b/src/DotNetty.Common/Internal/TextEncodings.Utf16.NetCore.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP_3_0_GREATER
+﻿#if NET6_0_OR_GREATER
 namespace DotNetty.Common.Internal
 {
     using System;

--- a/src/DotNetty.Common/Internal/TextEncodings.Utf16.NetFx.cs
+++ b/src/DotNetty.Common/Internal/TextEncodings.Utf16.NetFx.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP_3_0_GREATER
+﻿#if !NET6_0_OR_GREATER
 
 namespace DotNetty.Common.Internal
 {

--- a/src/DotNetty.Common/Internal/TextEncodings.Utf8.NetCore.cs
+++ b/src/DotNetty.Common/Internal/TextEncodings.Utf8.NetCore.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP_3_0_GREATER
+﻿#if NET6_0_OR_GREATER
 namespace DotNetty.Common.Internal
 {
     using System;

--- a/src/DotNetty.Common/Internal/TextEncodings.Utf8.NetFx.cs
+++ b/src/DotNetty.Common/Internal/TextEncodings.Utf8.NetFx.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP_3_0_GREATER
+﻿#if !NET6_0_OR_GREATER
 
 namespace DotNetty.Common.Internal
 {

--- a/src/DotNetty.Common/Internal/TextEncodings.Utf8.cs
+++ b/src/DotNetty.Common/Internal/TextEncodings.Utf8.cs
@@ -74,7 +74,7 @@
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static int GetBytes(in ReadOnlySpan<char> chars, Span<byte> bytes)
             {
-#if NETCOREAPP_2_X_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 return UTF8NoBOM.GetBytes(chars, bytes);
 #else
                 if (chars.IsEmpty) { return 0; }

--- a/src/DotNetty.Common/Internal/TextEncodings.cs
+++ b/src/DotNetty.Common/Internal/TextEncodings.cs
@@ -27,7 +27,7 @@
         private const char LowSurrogateStart = '\udc00';
         private const char LowSurrogateEnd = '\udfff';
 
-#if !NETCOREAPP_3_0_GREATER
+#if !NET6_0_OR_GREATER
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe static int PtrDiff(char* a, char* b)

--- a/src/DotNetty.Common/Internal/Utf16Utility.cs
+++ b/src/DotNetty.Common/Internal/Utf16Utility.cs
@@ -4,7 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
 

--- a/src/DotNetty.Common/Internal/Utf8Util.Helpers.cs
+++ b/src/DotNetty.Common/Internal/Utf8Util.Helpers.cs
@@ -4,7 +4,7 @@
 
 // borrowed from https://github.com/dotnet/corefxlab/tree/master/src/System.Text.Primitives/System/Text/Encoders
 
-#if !NETCOREAPP_3_0_GREATER
+#if !NET6_0_OR_GREATER
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/DotNetty.Common/Internal/Utf8Util.Validation.cs
+++ b/src/DotNetty.Common/Internal/Utf8Util.Validation.cs
@@ -4,7 +4,7 @@
 
 // borrowed from https://github.com/dotnet/corefxlab/tree/master/src/System.Text.Primitives/System/Text/Encoders
 
-#if !NETCOREAPP_3_0_GREATER
+#if !NET6_0_OR_GREATER
 using System;
 using System.Diagnostics;
 using System.Numerics;

--- a/src/DotNetty.Common/Internal/Utf8Utility.Helpers.cs
+++ b/src/DotNetty.Common/Internal/Utf8Utility.Helpers.cs
@@ -4,7 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers.Binary;
 using System.Diagnostics;

--- a/src/DotNetty.Common/Internal/Utf8Utility.Validation.cs
+++ b/src/DotNetty.Common/Internal/Utf8Utility.Validation.cs
@@ -4,7 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Diagnostics;
 using System.Numerics;

--- a/src/DotNetty.Common/Internal/Utf8Utility.WhiteSpace.cs
+++ b/src/DotNetty.Common/Internal/Utf8Utility.WhiteSpace.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/DotNetty.Common/Internal/Utf8Utility.cs
+++ b/src/DotNetty.Common/Internal/Utf8Utility.cs
@@ -4,7 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/DotNetty.Common/Utilities/AsciiString.NetCore3.cs
+++ b/src/DotNetty.Common/Utilities/AsciiString.NetCore3.cs
@@ -20,7 +20,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
 
 namespace DotNetty.Common.Utilities
 {

--- a/src/DotNetty.Common/Utilities/AsciiString.cs
+++ b/src/DotNetty.Common/Utilities/AsciiString.cs
@@ -92,7 +92,7 @@ namespace DotNetty.Common.Utilities
                 ThrowIndexOutOfRangeException_Start(start, length, value.Length);
             }
 
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             Span<byte> span = this.value = new byte[length];
             GetBytes(value.AsSpan(start, length), span);
 #else
@@ -129,7 +129,7 @@ namespace DotNetty.Common.Utilities
             }
 
             var thisVal = new byte[length];
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             switch (value)
             {
                 case IHasAsciiSpan asciiSpan:
@@ -144,7 +144,7 @@ namespace DotNetty.Common.Utilities
             {
                 thisVal[i] = CharToByte(value[j]);
             }
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
                     break;
             }
 #endif
@@ -184,7 +184,7 @@ namespace DotNetty.Common.Utilities
             }
 
             var thisVal = new byte[length];
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             GetBytes(value.AsSpan(start, length), thisVal);
 #else
             var len = start + length;
@@ -309,7 +309,7 @@ namespace DotNetty.Common.Utilities
 
             if (this.stringValue is object)
             {
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 return string.Equals(this.stringValue, a);
 #else
                 return string.Equals(this.stringValue, a, StringComparison.Ordinal);

--- a/src/DotNetty.Common/Utilities/StringBuilderCharSequence.cs
+++ b/src/DotNetty.Common/Utilities/StringBuilderCharSequence.cs
@@ -192,7 +192,7 @@ namespace DotNetty.Common.Utilities
             }
 
             return other is object && this.size == other.size && string.Equals(this.builder.ToString(this.offset, this.size), other.builder.ToString(other.offset, this.size)
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 );
 #else
                 , StringComparison.Ordinal);
@@ -207,7 +207,7 @@ namespace DotNetty.Common.Utilities
             {
                 case StringBuilderCharSequence comparand:
                     return this.size == comparand.size && string.Equals(this.builder.ToString(this.offset, this.size), comparand.builder.ToString(comparand.offset, this.size)
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         );
 #else
                         , StringComparison.Ordinal);
@@ -232,7 +232,7 @@ namespace DotNetty.Common.Utilities
             {
                 case StringBuilderCharSequence other:
                     return this.size == other.size && string.Equals(this.builder.ToString(this.offset, this.size), other.builder.ToString(other.offset, this.size)
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         );
 #else
                         , StringComparison.Ordinal);

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Handlers</RootNamespace>
     <AssemblyName>SpanNetty.Handlers</AssemblyName>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Handlers</RootNamespace>
     <AssemblyName>SpanNetty.Handlers</AssemblyName>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/src/DotNetty.Handlers/Tls/ApplicationProtocolNegotiationHandler.cs
+++ b/src/DotNetty.Handlers/Tls/ApplicationProtocolNegotiationHandler.cs
@@ -20,7 +20,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
 namespace DotNetty.Handlers.Tls
 {
     using System;

--- a/src/DotNetty.Handlers/Tls/ClientTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ClientTlsSettings.cs
@@ -51,7 +51,7 @@ namespace DotNetty.Handlers.Tls
 
         public ClientTlsSettings(bool checkCertificateRevocation, List<X509Certificate> certificates, string targetHost)
           : this(
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             SslProtocols.Tls13 |
 #endif
             SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
@@ -91,7 +91,7 @@ namespace DotNetty.Handlers.Tls
             return this;
         }
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         public System.Collections.Generic.List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 
         public Func<IChannelHandlerContext, string, X509CertificateCollection, X509Certificate, string[], X509Certificate2> UserCertSelector { get; set; }

--- a/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
@@ -54,7 +54,7 @@ namespace DotNetty.Handlers.Tls
                 s_defaultServerProtocol = SslProtocols.Tls12 | SslProtocols.Tls11;
             }
 #endif
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
             s_defaultServerProtocol |= SslProtocols.Tls13;
 #endif
             s_clientCertificateValidation = (_, __, ___) => true;
@@ -121,7 +121,7 @@ namespace DotNetty.Handlers.Tls
             return this;
         }
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         public System.Collections.Generic.List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 
         /// <summary>A callback that will be invoked to dynamically select a server certificate. This is higher priority than ServerCertificate.

--- a/src/DotNetty.Handlers/Tls/TlsHandler.Handshake.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.Handshake.cs
@@ -35,7 +35,7 @@ namespace DotNetty.Handlers.Tls
     using System.Threading.Tasks;
     using DotNetty.Common.Utilities;
     using DotNetty.Transport.Channels;
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
 #endif
@@ -77,7 +77,7 @@ namespace DotNetty.Handlers.Tls
         {
             if (_isServer)
             {
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 // Adapt to the SslStream signature
                 ServerCertificateSelectionCallback selector = null;
                 if (_serverCertificateSelector is object)
@@ -118,7 +118,7 @@ namespace DotNetty.Handlers.Tls
             }
             else
             {
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 LocalCertificateSelectionCallback selector = null;
                 if (_userCertSelector is object)
                 {
@@ -159,7 +159,7 @@ namespace DotNetty.Handlers.Tls
 
         private static void HandshakeCompletionCallback(Task task, object s)
         {
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
             var (self, cts) = ((TlsHandler self, CancellationTokenSource cts))s;
             cts.Dispose();
 #else

--- a/src/DotNetty.Handlers/Tls/TlsHandler.Helper.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.Helper.cs
@@ -85,7 +85,7 @@ namespace DotNetty.Handlers.Tls
                 return new SslStream(stream,
                     leaveInnerStreamOpen: true,
                     userCertificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => ServerCertificateValidation(sender, certificate, chain, sslPolicyErrors, clientSettings)
-#if !(NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER)
+#if !(NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER)
                     , userCertificateSelectionCallback: clientSettings.UserCertSelector is null ? null : new LocalCertificateSelectionCallback((sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) =>
                     {
                         return clientSettings.UserCertSelector(sender as SslStream, targetHost, localCertificates, remoteCertificate, acceptableIssuers);

--- a/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
@@ -45,7 +45,7 @@ namespace DotNetty.Handlers.Tls
         private IPromise _lastContextWritePromise;
         private volatile int v_wrapDataSize = TlsUtils.MAX_PLAINTEXT_LENGTH;
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER || NETSTANDARD2_0
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER || NETSTANDARD2_0
         private Task _lastAsyncWriteTask; 
 #endif        
 
@@ -178,7 +178,7 @@ namespace DotNetty.Handlers.Tls
                         _lastContextWritePromise = promise;
                         if (buf.IsReadable())
                         {
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                             var asyncWrite = WriteAsync(buf, promise);
                             if (!asyncWrite.IsCompleted)
                             {

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -51,7 +51,7 @@ namespace DotNetty.Handlers.Tls
         private readonly ServerTlsSettings _serverSettings;
         private readonly ClientTlsSettings _clientSettings;
         private readonly X509Certificate _serverCertificate;
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         private readonly Func<IChannelHandlerContext, string, X509Certificate2> _serverCertificateSelector;
         private readonly Func<IChannelHandlerContext, string, X509CertificateCollection, X509Certificate, string[], X509Certificate2> _userCertSelector;
 #endif
@@ -113,7 +113,7 @@ namespace DotNetty.Handlers.Tls
 
                 // capture the certificate now so it can't be switched after validation
                 _serverCertificate = _serverSettings.Certificate;
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 _serverCertificateSelector = _serverSettings.ServerCertificateSelector;
                 if (_serverCertificate is null && _serverCertificateSelector is null)
 #else
@@ -124,7 +124,7 @@ namespace DotNetty.Handlers.Tls
                 }
             }
             _clientSettings = settings as ClientTlsSettings;
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
             if (_clientSettings is object)
             {
                 _userCertSelector = _clientSettings.UserCertSelector;
@@ -143,7 +143,7 @@ namespace DotNetty.Handlers.Tls
 
         public bool IsServer => _isServer;
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         public SslApplicationProtocol NegotiatedApplicationProtocol => _sslStream is object ? _sslStream.NegotiatedApplicationProtocol : default;
 #endif
 

--- a/src/DotNetty.Handlers/Tls/TlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/TlsSettings.cs
@@ -29,7 +29,7 @@
 namespace DotNetty.Handlers.Tls
 {
     using System.Security.Authentication;
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
     using System;
     using System.Runtime.CompilerServices;
     using System.Threading;
@@ -49,7 +49,7 @@ namespace DotNetty.Handlers.Tls
         /// <summary>Specifies whether the certificate revocation list is checked during authentication.</summary>
         public bool CheckCertificateRevocation { get; }
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         private static readonly TimeSpan DefaultHandshakeTimeout = TimeSpan.FromSeconds(10);
         private static readonly TimeSpan MaximumHandshakeTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 

--- a/src/DotNetty.Transport/Channels/DefaultChannelPipeline.cs
+++ b/src/DotNetty.Transport/Channels/DefaultChannelPipeline.cs
@@ -542,7 +542,7 @@ namespace DotNetty.Transport.Channels
                 else
                 {
                     bool sameName = string.Equals(ctx.Name, newName
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         );
 #else
                         , StringComparison.Ordinal);
@@ -977,7 +977,7 @@ namespace DotNetty.Transport.Channels
             while (context != _tail)
             {
                 if (string.Equals(context.Name, name
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     ))
 #else
                     , StringComparison.Ordinal))

--- a/src/DotNetty.Transport/Channels/Local/LocalAddress.cs
+++ b/src/DotNetty.Transport/Channels/Local/LocalAddress.cs
@@ -71,7 +71,7 @@ namespace DotNetty.Transport.Channels.Local
         {
             if (ReferenceEquals(this, other)) { return true; }
             return other is object && string.Equals(_strVal, other._strVal
-#if NETCOREAPP_3_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                         );
 #else
                         , StringComparison.Ordinal);

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -235,9 +235,9 @@ namespace DotNetty.Transport.Channels.Sockets
             var @unsafe = channel.Unsafe;
             IEventLoop eventLoop = channel.EventLoop;
             
-            if (operation.SocketError == SocketError.OperationAborted // means System.Net.Sockets.Socket was closed. Most probably the callback was invoked because socket was closed, not because IO operation completed.
-                && !channel.IsOpen // channel is already closed, meaning this is an expected closure
-            )
+            if ((operation.LastOperation == SocketAsyncOperation.Receive || operation.LastOperation == SocketAsyncOperation.ReceiveFrom)
+                && (operation.SocketError == SocketError.OperationAborted || operation.SocketError == SocketError.Success) // means System.Net.Sockets.Socket was closed. Most probably the callback was invoked because socket was closed, not because IO operation completed.
+                && !channel.IsOpen) // channel is already closed, meaning this is an expected closure
             {
                 if (Logger.DebugEnabled) Logger.AbstractSocketIoCallbackSkipped(operation, channel);
                 return;

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -235,8 +235,7 @@ namespace DotNetty.Transport.Channels.Sockets
             var @unsafe = channel.Unsafe;
             IEventLoop eventLoop = channel.EventLoop;
             
-            if ((operation.LastOperation == SocketAsyncOperation.Receive || operation.LastOperation == SocketAsyncOperation.ReceiveFrom)
-                && (operation.SocketError == SocketError.OperationAborted || operation.SocketError == SocketError.Success) // means System.Net.Sockets.Socket was closed. Most probably the callback was invoked because socket was closed, not because IO operation completed.
+            if ((operation.SocketError == SocketError.OperationAborted || operation.SocketError == SocketError.Success) // means System.Net.Sockets.Socket was closed. Most probably the callback was invoked because socket was closed, not because IO operation completed.
                 && !channel.IsOpen) // channel is already closed, meaning this is an expected closure
             {
                 if (Logger.DebugEnabled) Logger.AbstractSocketIoCallbackSkipped(operation, channel);

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Transport</RootNamespace>
     <AssemblyName>SpanNetty.Transport</AssemblyName>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(DotNetTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppTfms);netstandard2.1;$(StandardTfms)</TargetFrameworks>
     <RootNamespace>DotNetty.Transport</RootNamespace>
     <AssemblyName>SpanNetty.Transport</AssemblyName>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,9 +3,9 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <DeveloperBuildTestTfms>net6.0</DeveloperBuildTestTfms>
-    <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">net6.0</StandardTestTfms>
+    <NetCoreAppTfms>net6.0;net8.0;net9.0</NetCoreAppTfms>
+    <StandardTestTfms>$(NetCoreAppTfms)</StandardTestTfms>
+    <!--<StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">net6.0</StandardTestTfms>-->
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net471</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <NetCoreAppTfms>net6.0;net8.0;net9.0</NetCoreAppTfms>
     <StandardTestTfms>$(NetCoreAppTfms)</StandardTestTfms>
-    <!--<StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">net6.0</StandardTestTfms>-->
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net471</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/DotNetty.Buffers.ReaderWriter.Tests/DotNetty.Buffers.ReaderWriter.Tests.csproj
+++ b/test/DotNetty.Buffers.ReaderWriter.Tests/DotNetty.Buffers.ReaderWriter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/test/DotNetty.Buffers.Tests/run.net.cmd
+++ b/test/DotNetty.Buffers.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Codecs.Http.Tests/run.net.cmd
+++ b/test/DotNetty.Codecs.Http.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Codecs.Http2.Tests/DataCompressionHttp2Test.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/DataCompressionHttp2Test.cs
@@ -1,6 +1,4 @@
 ﻿
-using System.Net.Sockets;
-
 namespace DotNetty.Codecs.Http2.Tests
 {
     using System;
@@ -96,27 +94,6 @@ namespace DotNetty.Codecs.Http2.Tests
         protected override void SetupBootstrap(Bootstrap bootstrap)
         {
             bootstrap.Group(new MultithreadEventLoopGroup(new LoggingRejectionHandler(this.Output))).Channel<TcpSocketChannel>();
-        }
-        
-        public class LoggingRejectionHandler : IRejectedExecutionHandler
-        {
-            private readonly ITestOutputHelper _output;
-
-            public LoggingRejectionHandler(ITestOutputHelper output)
-            {
-                _output = output;
-            }
-
-            public void Rejected(IRunnable task, SingleThreadEventExecutor executor)
-            {
-                if (task is AbstractExecutorService.StateActionWithContextTaskQueueNode node)
-                {
-                    var socketEventArgs = node.State as SocketAsyncEventArgs;
-                    _output.WriteLine($"Callback action scheduling rejected. Task type: {task.GetType()}, State type: {node.State?.GetType()}, Socket operation: {socketEventArgs?.LastOperation}, Socket error: {socketEventArgs?.SocketError}");
-                }
-                
-                throw new RejectedExecutionException();
-            }
         }
     }
 

--- a/test/DotNetty.Codecs.Http2.Tests/Http2ConnectionHandlerTest.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/Http2ConnectionHandlerTest.cs
@@ -913,7 +913,11 @@ namespace DotNetty.Codecs.Http2.Tests
                     x => x.Schedule(
                         It.IsAny<Action<object>>(),
                         It.IsAny<object>(),
-                        It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis))),
+                        It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis
+#if NET9_0
+                        , 0L 
+#endif                        
+                    ))),
                     Times.AtLeastOnce());
             }
             else
@@ -923,7 +927,11 @@ namespace DotNetty.Codecs.Http2.Tests
                         It.IsAny<Action<object, object>>(),
                         It.IsAny<object>(),
                         It.IsAny<object>(),
-                        It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis))),
+                        It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis
+#if NET9_0
+                            , 0L 
+#endif    
+                    ))),
                     Times.AtLeastOnce());
             }
         }
@@ -939,7 +947,11 @@ namespace DotNetty.Codecs.Http2.Tests
                 x => x.Schedule(
                     It.IsAny<Action<object>>(),
                     It.IsAny<object>(),
-                    It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis))),
+                    It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis
+#if NET9_0
+                        , 0L 
+#endif                    
+                ))),
                 Times.AtLeastOnce());
         }
 
@@ -958,7 +970,11 @@ namespace DotNetty.Codecs.Http2.Tests
                     It.IsAny<Action<object, object>>(),
                     It.IsAny<object>(),
                     It.IsAny<object>(),
-                    It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis))),
+                    It.Is<TimeSpan>(v => v == TimeSpan.FromMilliseconds(expectedMillis
+#if NET9_0
+                        , 0L 
+#endif    
+                ))),
                 Times.AtLeastOnce());
         }
 

--- a/test/DotNetty.Codecs.Http2.Tests/Http2ConnectionRoundtripTest.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/Http2ConnectionRoundtripTest.cs
@@ -62,13 +62,13 @@ namespace DotNetty.Codecs.Http2.Tests
 
         protected override void SetupServerBootstrap(ServerBootstrap bootstrap)
         {
-            bootstrap.Group(new MultithreadEventLoopGroup(1), new MultithreadEventLoopGroup())
+            bootstrap.Group(new MultithreadEventLoopGroup(1), new MultithreadEventLoopGroup(new LoggingRejectionHandler(this.Output)))
                      .Channel<TcpServerSocketChannel>();
         }
 
         protected override void SetupBootstrap(Bootstrap bootstrap)
         {
-            bootstrap.Group(new MultithreadEventLoopGroup()).Channel<TcpSocketChannel>();
+            bootstrap.Group(new MultithreadEventLoopGroup(new LoggingRejectionHandler(this.Output))).Channel<TcpSocketChannel>();
         }
 
         [Fact(Skip = "slow")] // TODO https://github.com/cuteant/SpanNetty/issues/66

--- a/test/DotNetty.Codecs.Http2.Tests/HttpToHttp2ConnectionHandlerTest.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/HttpToHttp2ConnectionHandlerTest.cs
@@ -55,13 +55,13 @@ namespace DotNetty.Codecs.Http2.Tests
 
         protected override void SetupServerBootstrap(ServerBootstrap bootstrap)
         {
-            bootstrap.Group(new MultithreadEventLoopGroup(1), new MultithreadEventLoopGroup())
+            bootstrap.Group(new MultithreadEventLoopGroup(1), new MultithreadEventLoopGroup(new LoggingRejectionHandler(this.Output)))
                      .Channel<TcpServerSocketChannel>();
         }
 
         protected override void SetupBootstrap(Bootstrap bootstrap)
         {
-            bootstrap.Group(new MultithreadEventLoopGroup()).Channel<TcpSocketChannel>();
+            bootstrap.Group(new MultithreadEventLoopGroup(new LoggingRejectionHandler(this.Output))).Channel<TcpSocketChannel>();
         }
     }
 

--- a/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Sockets;
-using DotNetty.Common.Concurrency;
+﻿using DotNetty.Common.Concurrency;
 using Xunit.Abstractions;
 
 namespace DotNetty.Codecs.Http2.Tests;
@@ -15,17 +14,7 @@ public class LoggingRejectionHandler : IRejectedExecutionHandler
 
     public void Rejected(IRunnable task, SingleThreadEventExecutor executor)
     {
-        string message;
-        if (task is AbstractExecutorService.StateActionWithContextTaskQueueNode node)
-        {
-            var socketEventArgs = node.State as SocketAsyncEventArgs;
-            message = $"Callback action scheduling rejected. Task type: {task.GetType()}, State type: {node.State?.GetType()}, Socket operation: {socketEventArgs?.LastOperation}, Socket error: {socketEventArgs?.SocketError}";
-        }
-        else
-        {
-            message = $"Callback action scheduling rejected. Task type: {task.GetType()}";
-        }
-                
+        var message = $"Callback action scheduling rejected. Task type: {task.GetType()}";
         _output.WriteLine(message);
         throw new RejectedExecutionException(message);
     }

--- a/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
@@ -15,16 +15,18 @@ public class LoggingRejectionHandler : IRejectedExecutionHandler
 
     public void Rejected(IRunnable task, SingleThreadEventExecutor executor)
     {
+        string message;
         if (task is AbstractExecutorService.StateActionWithContextTaskQueueNode node)
         {
             var socketEventArgs = node.State as SocketAsyncEventArgs;
-            _output.WriteLine($"Callback action scheduling rejected. Task type: {task.GetType()}, State type: {node.State?.GetType()}, Socket operation: {socketEventArgs?.LastOperation}, Socket error: {socketEventArgs?.SocketError}");
+            message = $"Callback action scheduling rejected. Task type: {task.GetType()}, State type: {node.State?.GetType()}, Socket operation: {socketEventArgs?.LastOperation}, Socket error: {socketEventArgs?.SocketError}";
         }
         else
         {
-            _output.WriteLine($"Callback action scheduling rejected. Task type: {task.GetType()}");   
+            message = $"Callback action scheduling rejected. Task type: {task.GetType()}";
         }
                 
-        throw new RejectedExecutionException();
+        _output.WriteLine(message);
+        throw new RejectedExecutionException(message);
     }
 }

--- a/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
@@ -20,6 +20,10 @@ public class LoggingRejectionHandler : IRejectedExecutionHandler
             var socketEventArgs = node.State as SocketAsyncEventArgs;
             _output.WriteLine($"Callback action scheduling rejected. Task type: {task.GetType()}, State type: {node.State?.GetType()}, Socket operation: {socketEventArgs?.LastOperation}, Socket error: {socketEventArgs?.SocketError}");
         }
+        else
+        {
+            _output.WriteLine($"Callback action scheduling rejected. Task type: {task.GetType()}");   
+        }
                 
         throw new RejectedExecutionException();
     }

--- a/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/LoggingRejectionHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Net.Sockets;
+using DotNetty.Common.Concurrency;
+using Xunit.Abstractions;
+
+namespace DotNetty.Codecs.Http2.Tests;
+
+public class LoggingRejectionHandler : IRejectedExecutionHandler
+{
+    private readonly ITestOutputHelper _output;
+
+    public LoggingRejectionHandler(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public void Rejected(IRunnable task, SingleThreadEventExecutor executor)
+    {
+        if (task is AbstractExecutorService.StateActionWithContextTaskQueueNode node)
+        {
+            var socketEventArgs = node.State as SocketAsyncEventArgs;
+            _output.WriteLine($"Callback action scheduling rejected. Task type: {task.GetType()}, State type: {node.State?.GetType()}, Socket operation: {socketEventArgs?.LastOperation}, Socket error: {socketEventArgs?.SocketError}");
+        }
+                
+        throw new RejectedExecutionException();
+    }
+}

--- a/test/DotNetty.Codecs.Http2.Tests/run.net.cmd
+++ b/test/DotNetty.Codecs.Http2.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Codecs.Mqtt.Tests/run.net.cmd
+++ b/test/DotNetty.Codecs.Mqtt.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Codecs.Protobuf.Tests/run.net.cmd
+++ b/test/DotNetty.Codecs.Protobuf.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Codecs.Redis.Tests/run.net.cmd
+++ b/test/DotNetty.Codecs.Redis.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Codecs.Tests/run.net.cmd
+++ b/test/DotNetty.Codecs.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -6,9 +6,6 @@
     <AssemblyName>DotNetty.Common.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup  Condition=" '$(TargetFramework)' == 'net6.0'">
-    <DefineConstants>$(DefineConstants);CORELIBTEST</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(ImportLibs)' == 'netfx' ">
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/ASCIIUtilityTests.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/ASCIIUtilityTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Numerics;

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.Creation.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.Creation.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 using System.Runtime.InteropServices;
 

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.Unix.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.Unix.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 
 namespace DotNetty.Common.Tests.Internal.CoreLib

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.Windows.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.Windows.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Runtime.ConstrainedExecution;

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/BoundedMemory.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 
 namespace DotNetty.Common.Tests.Internal.CoreLib

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/PoisonPagePlacement.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/PoisonPagePlacement.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 namespace DotNetty.Common.Tests.Internal.CoreLib
 {
     /// <summary>

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/Utf16UtilityTests.ValidateChars.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/Utf16UtilityTests.ValidateChars.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Globalization;

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/Utf8Tests.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/Utf8Tests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/test/DotNetty.Common.Tests/Internal/CoreLib/Utf8UtilityTests.ValidateBytes.cs
+++ b/test/DotNetty.Common.Tests/Internal/CoreLib/Utf8UtilityTests.ValidateBytes.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if CORELIBTEST
+#if NET6_0_OR_GREATER
 using System;
 using System.Buffers;
 using System.Linq;

--- a/test/DotNetty.Common.Tests/Utilities/HashedWheelTimerTest.cs
+++ b/test/DotNetty.Common.Tests/Utilities/HashedWheelTimerTest.cs
@@ -22,7 +22,7 @@ namespace DotNetty.Common.Tests.Utilities
         [Fact]
         public void TestScheduleTimeoutShouldNotRunBeforeDelay()
         {
-            ITimer timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(100), 512, -1);
+            var timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(100), 512, -1);
             var barrier = new CountdownEvent(1);
             ITimeout timeout = timer.NewTimeout(
                 new ActionTimerTask(
@@ -40,7 +40,7 @@ namespace DotNetty.Common.Tests.Utilities
         [Fact]
         public void TestScheduleTimeoutShouldRunAfterDelay()
         {
-            ITimer timer = new HashedWheelTimer();
+            var timer = new HashedWheelTimer();
             var barrier = new CountdownEvent(1);
             ITimeout timeout = timer.NewTimeout(
                 new ActionTimerTask(
@@ -55,7 +55,7 @@ namespace DotNetty.Common.Tests.Utilities
         public void TestStopTimer()
         {
             var latch = new CountdownEvent(3);
-            ITimer timerProcessed = new HashedWheelTimer();
+            var timerProcessed = new HashedWheelTimer();
             for (int i = 0; i < 3; i++)
             {
                 timerProcessed.NewTimeout(
@@ -67,7 +67,7 @@ namespace DotNetty.Common.Tests.Utilities
             latch.Wait();
             Assert.Equal(0, timerProcessed.StopAsync().Result.Count); // "Number of unprocessed timeouts should be 0"
 
-            ITimer timerUnprocessed = new HashedWheelTimer();
+            var timerUnprocessed = new HashedWheelTimer();
             for (int i = 0; i < 5; i++)
             {
                 timerUnprocessed.NewTimeout(
@@ -83,7 +83,7 @@ namespace DotNetty.Common.Tests.Utilities
         public void TestTimerShouldThrowExceptionAfterShutdownForNewTimeouts()
         {
             var latch = new CountdownEvent(3);
-            ITimer timer = new HashedWheelTimer();
+            var timer = new HashedWheelTimer();
             for (int i = 0; i < 3; i++)
             {
                 timer.NewTimeout(

--- a/test/DotNetty.Common.Tests/run.net.cmd
+++ b/test/DotNetty.Common.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.End2End.Tests/run.net.cmd
+++ b/test/DotNetty.End2End.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Handlers.Tests/SniHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/SniHandlerTest.cs
@@ -32,7 +32,7 @@ namespace DotNetty.Handlers.Tests
             X509Certificate2 tlsCertificate = TestResourceHelper.GetTestCertificate();
             X509Certificate2 tlsCertificate2 = TestResourceHelper.GetTestCertificate2();
 
-            //#if NETCOREAPP_3_0_GREATER
+            //#if NET6_0_OR_GREATER
             //            SslProtocols serverProtocol = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? SslProtocols.Tls13 : SslProtocols.Tls12;
             //#else
             SslProtocols serverProtocol = SslProtocols.Tls12;
@@ -53,7 +53,7 @@ namespace DotNetty.Handlers.Tests
                 new[] { 1 }
             };
             var boolToggle = new[] { false, true };
-            //#if NETCOREAPP_3_0_GREATER
+            //#if NET6_0_OR_GREATER
             //            var protocols = new[] { RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? SslProtocols.Tls13 : SslProtocols.Tls12 };
             //#else
             var protocols = new[] { SslProtocols.Tls12 };
@@ -133,7 +133,7 @@ namespace DotNetty.Handlers.Tests
                 new[] { 1 }
             };
             var boolToggle = new[] { false, true };
-            //#if NETCOREAPP_3_0_GREATER
+            //#if NET6_0_OR_GREATER
             //            var protocols = new[] { RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? SslProtocols.Tls13 : SslProtocols.Tls12 };
             //#else
             var protocols = new[] { SslProtocols.Tls12 };

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -58,7 +58,7 @@ namespace DotNetty.Handlers.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 protocols.Add(Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12));
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
                 //protocols.Add(Tuple.Create(SslProtocols.Tls13, SslProtocols.Tls13));
 #endif
                 protocols.Add(Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls, SslProtocols.Tls12 | SslProtocols.Tls11));
@@ -159,7 +159,7 @@ namespace DotNetty.Handlers.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 protocols.Add(Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12));
-#if NETCOREAPP_3_0_GREATER
+#if NET6_0_OR_GREATER
                 //protocols.Add(Tuple.Create(SslProtocols.Tls13, SslProtocols.Tls13));
 #endif
                 protocols.Add(Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls, SslProtocols.Tls12 | SslProtocols.Tls11));

--- a/test/DotNetty.Handlers.Tests/run.net.cmd
+++ b/test/DotNetty.Handlers.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Suite.Tests/run.net.cmd
+++ b/test/DotNetty.Suite.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
+++ b/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>DotNetty.Transport.Libuv.Tests</AssemblyName>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup  Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net471' ">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);SKIPTESTINAZUREDEVOPS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(ImportLibs)' == 'netfx' ">

--- a/test/DotNetty.Transport.Libuv.Tests/run.net.cmd
+++ b/test/DotNetty.Transport.Libuv.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64

--- a/test/DotNetty.Transport.Tests/Channel/Sockets/TcpSocketChannelTest.cs
+++ b/test/DotNetty.Transport.Tests/Channel/Sockets/TcpSocketChannelTest.cs
@@ -47,12 +47,12 @@
                 socket.ConnectAsync(sc.LocalAddress).GetAwaiter().GetResult();
 
                 byte[] tempArea = new byte[8192];
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                 Span<byte> buf = tempArea;
 #endif
                 while (true)
                 {
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
                     var byteCount = socket.Receive(buf);
 #else
                     var byteCount = socket.Receive(tempArea);
@@ -105,7 +105,7 @@
             }
         }
 
-#if NETCOREAPP_2_0_GREATER || NETSTANDARD_2_0_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD_2_0_GREATER
         /**
          * Reproduces the issue #1679
          */

--- a/test/DotNetty.Transport.Tests/run.net.cmd
+++ b/test/DotNetty.Transport.Tests/run.net.cmd
@@ -1,1 +1,1 @@
-dotnet test --framework net6.0 -- RunConfiguration.TargetPlatform=x64
+dotnet test --framework net9.0 -- RunConfiguration.TargetPlatform=x64


### PR DESCRIPTION
- Add net8 and net9 as target frameworks for non-standard-only projects and tests
- switch tests from net6 to net9