### PR TITLE
fix: Align maximum header size to HTTP.SYS

### DIFF
--- a/src/DotNetty.Codecs.Http2/DefaultHttp2HeadersDecoder.cs
+++ b/src/DotNetty.Codecs.Http2/DefaultHttp2HeadersDecoder.cs
@@ -93,16 +93,12 @@ namespace DotNetty.Codecs.Http2
             _maxHeaderListSizeGoAway = Http2CodecUtil.CalculateMaxHeaderListSizeGoAway(hpackDecoder.GetMaxHeaderListSize());
         }
 
-
         public void SetMaxHeaderTableSize(long max)
         {
             _hpackDecoder.SetMaxHeaderTableSize(max);
         }
 
-
-
         public long MaxHeaderTableSize => _hpackDecoder.GetMaxHeaderTableSize();
-
 
         public void SetMaxHeaderListSize(long max, long goAwayMax)
         {

--- a/src/DotNetty.Codecs.Http2/Http2CodecUtil.cs
+++ b/src/DotNetty.Codecs.Http2/Http2CodecUtil.cs
@@ -139,7 +139,7 @@ namespace DotNetty.Codecs.Http2
         /// However in practice we don't want to allow our peers to use unlimited memory by default. So we take advantage
         /// of the <c>For any given request, a lower limit than what is advertised MAY be enforced.</c> loophole.
         /// </summary>
-        public const long DefaultHeaderListSize = 8192;
+        public const long DefaultHeaderListSize = 16384;
 
         public const int DefaultMaxFrameSize = MaxFrameSizeLowerBound;
 

--- a/src/DotNetty.Codecs.Http2/Http2CodecUtil.cs
+++ b/src/DotNetty.Codecs.Http2/Http2CodecUtil.cs
@@ -132,7 +132,7 @@ namespace DotNetty.Codecs.Http2
 
         public const short DefaultPriorityWeight = 16;
 
-        public const int DefaultHeaderTableSize = 4096;
+        public const int DefaultHeaderTableSize = 16384;
 
         /// <summary>
         /// <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">The initial value of this setting is unlimited</a>.

--- a/src/DotNetty.Codecs.Http2/Http2CodecUtil.cs
+++ b/src/DotNetty.Codecs.Http2/Http2CodecUtil.cs
@@ -132,14 +132,14 @@ namespace DotNetty.Codecs.Http2
 
         public const short DefaultPriorityWeight = 16;
 
-        public const int DefaultHeaderTableSize = 16384;
+        public const int DefaultHeaderTableSize = 16_384;
 
         /// <summary>
         /// <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">The initial value of this setting is unlimited</a>.
         /// However in practice we don't want to allow our peers to use unlimited memory by default. So we take advantage
         /// of the <c>For any given request, a lower limit than what is advertised MAY be enforced.</c> loophole.
         /// </summary>
-        public const long DefaultHeaderListSize = 16384;
+        public const long DefaultHeaderListSize = 16_384;
 
         public const int DefaultMaxFrameSize = MaxFrameSizeLowerBound;
 

--- a/test/DotNetty.Codecs.Http2.Tests/DefaultHttp2HeadersDecoderTest.cs
+++ b/test/DotNetty.Codecs.Http2.Tests/DefaultHttp2HeadersDecoderTest.cs
@@ -57,7 +57,7 @@ namespace DotNetty.Codecs.Http2.Tests
         public void DecodeLargerThanHeaderListSizeButLessThanGoAwayWithInitialDecoderSettings()
         {
             var buf = Encode(B(":method"), B("GET"), B("test_header"),
-                B("A".PadRight(9000, 'A')));
+                B("A".PadRight(16_300, 'A')));
             int streamId = 1;
             var e = Assert.Throws<HeaderListSizeException>(() => decoder.DecodeHeaders(streamId, buf));
             Assert.Equal(streamId, e.StreamId);


### PR DESCRIPTION
Ref: https://msazure.visualstudio.com/One/_workitems/edit/31304596

Align header size and total header size with [HTTP.SYS](https://learn.microsoft.com/en-us/troubleshoot/developer/webapps/iis/health-diagnostic-performance/httpsys-registry-windows).