### PR TITLE
Fix race condition in TlsHanlder.Wrap() on netstandard2.0 code path

### DIFF
--- a/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
@@ -150,6 +150,7 @@ namespace DotNetty.Handlers.Tls
         private void Wrap(IChannelHandlerContext context)
         {
             Debug.Assert(context == CapturedContext);
+            if (Volatile.Read(ref _outboundClosed)) { return; }
 
             IByteBufferAllocator alloc = context.Allocator;
             IByteBuffer buf = null;
@@ -188,7 +189,12 @@ namespace DotNetty.Handlers.Tls
                             }
                             buf = null; //prevent buf from releasing synchronously
 #else
-                            _ = buf.ReadBytes(_sslStream, readableBytes); // this leads to FinishWrap being called 0+ times
+                            var sslStream = _sslStream;
+                            if (sslStream is null)
+                            {
+                                throw s_sslStreamClosedException;
+                            }
+                            _ = buf.ReadBytes(sslStream, readableBytes); // this leads to FinishWrap being called 0+ times
 #endif
                         }
                         else if (promise != null)

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -293,14 +293,14 @@ namespace DotNetty.Handlers.Tls
             {
                 // Release all resources such as internal buffers that SSLEngine
                 // is managing.
-                _outboundClosed = true;
+                Volatile.Write(ref _outboundClosed, true);
                 _mediationStream.Dispose();
                 if (closeInbound)
                 {
                     try
                     {
-                        _sslStream?.Dispose();
-                        _sslStream = null;
+                        var oldSslStream = Interlocked.Exchange(ref _sslStream, null);
+                        oldSslStream?.Dispose();
                     }
                     catch (Exception)
                     {
@@ -334,10 +334,10 @@ namespace DotNetty.Handlers.Tls
 
         private void CloseOutboundAndChannel(IChannelHandlerContext context, IPromise promise, bool disconnect)
         {
-            _outboundClosed = true;
+            Volatile.Write(ref _outboundClosed, true);
             _mediationStream.Dispose();
-            _sslStream?.Dispose();
-            _sslStream = null;
+            var oldSslStream = Interlocked.Exchange(ref _sslStream, null);
+            oldSslStream?.Dispose();
 
             if (!context.Channel.IsActive)
             {

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -586,6 +586,70 @@ namespace DotNetty.Handlers.Tests
                 await executor.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.Zero);
             }
         }
+
+        [Fact]
+        public async Task WriteAfterOutboundClosedShouldNotThrowNullRef()
+        {
+            var executor = new DefaultEventExecutor();
+            try
+            {
+                var writeTasks = new List<Task>();
+                var pair = await SetupStreamAndChannelAsync(
+                    true, executor, new AsIsWriteStrategy(),
+                    SslProtocols.Tls12, SslProtocols.Tls12, writeTasks)
+                    .WithTimeout(TimeSpan.FromSeconds(10));
+                EmbeddedChannel ch = pair.Item1;
+                SslStream driverStream = pair.Item2;
+
+                var tlsHandler = ch.Pipeline.Get<TlsHandler>();
+                Assert.NotNull(tlsHandler);
+
+                // Simulate the race condition where teardown sets _outboundClosed = true
+                // and nulls _sslStream before Wrap() runs
+                var outboundClosedField = typeof(TlsHandler).GetField("_outboundClosed",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(outboundClosedField);
+                outboundClosedField.SetValue(tlsHandler, true);
+
+                var sslStreamField = typeof(TlsHandler).GetField("_sslStream",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(sslStreamField);
+                sslStreamField.SetValue(tlsHandler, null);
+
+                // Write data — Wrap() should early-exit due to _outboundClosed.
+                // The write promise won't complete (no teardown path to drain it),
+                // so we use a timeout and just verify no NullRef/ArgumentNull is thrown.
+                var buf = Unpooled.WrappedBuffer(new byte[] { 1, 2, 3, 4 });
+
+                Exception caughtException = null;
+                try
+                {
+                    var writeTask = ch.WriteAndFlushAsync(buf);
+                    // Wait briefly — if Wrap() exits early, the task just stays incomplete
+                    await Task.WhenAny(writeTask, Task.Delay(TimeSpan.FromSeconds(2)));
+                }
+                catch (Exception ex)
+                {
+                    caughtException = ex;
+                }
+
+                ch.RunPendingTasks();
+
+                // Should not have thrown NullReferenceException or ArgumentNullException
+                if (caughtException is not null)
+                {
+                    Assert.IsNotType<NullReferenceException>(caughtException);
+                    Assert.IsNotType<ArgumentNullException>(caughtException);
+                }
+
+                driverStream.Dispose();
+                try { await ch.CloseAsync(); } catch { }
+            }
+            finally
+            {
+                await executor.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.Zero);
+            }
+        }
 #endif
     }
 }


### PR DESCRIPTION
Fix a race condition inside SpanNetty's `TlsHandler.wrap()`, in which the internal `SslStream` reference (`_sslStream`) becomes null during concurrent channel teardown, causing `ArgumentNullException` when `ReadBytes(Stream destination, int length)` is called with a null destination.

On the `netstandard2.0` code path in `TlsHandler.Writer.cs`, the `Wrap()` method reads the `_sslStream` field directly without a local snapshot or null check

```csharp
// TlsHandler.Writer.cs, Wrap() method - netstandard2.0 code path
_ = buf.ReadBytes(_sslStream, readableBytes); // NOTE: _sslStream can be null here
```

It seems other fields (`CapturedContext` and `State`) do use `Volatile.Read` / `Interlocked.Exchange` but `_sslStream` was missed.